### PR TITLE
Unify PEX buildtime and runtime wheel caches.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -162,9 +162,9 @@ def configure_clp_pex_resolution(parser):
   group.add_option(
       '--cache-dir',
       dest='cache_dir',
-      default='{pex_root}/build',
+      default='{pex_root}',
       help='The local cache directory to use for speeding up requirement '
-           'lookups. [Default: ~/.pex/build]')
+           'lookups. [Default: ~/.pex]')
 
   group.add_option(
       '--wheel', '--no-wheel', '--no-use-wheel',
@@ -458,7 +458,7 @@ def configure_clp():
   parser.add_option(
       '--pex-root',
       dest='pex_root',
-      default=None,
+      default=ENV.PEX_ROOT,
       help='Specify the pex root used in this invocation of pex. [Default: ~/.pex]'
   )
 
@@ -625,16 +625,13 @@ def main(args=None):
   if options.python and options.interpreter_constraint:
     die('The "--python" and "--interpreter-constraint" options cannot be used together.')
 
-  if options.pex_root:
-    ENV.set('PEX_ROOT', options.pex_root)
-  else:
-    options.pex_root = ENV.PEX_ROOT  # If option not specified fallback to env variable.
+  with ENV.patch(PEX_VERBOSE=str(options.verbosity),
+                 PEX_ROOT=options.pex_root) as patched_env:
 
-  # Don't alter cache if it is disabled.
-  if options.cache_dir:
-    options.cache_dir = make_relative_to_root(options.cache_dir)
+    # Don't alter cache if it is disabled.
+    if options.cache_dir:
+      options.cache_dir = make_relative_to_root(options.cache_dir)
 
-  with ENV.patch(PEX_VERBOSE=str(options.verbosity)) as patched_env:
     with TRACER.timed('Building pex'):
       pex_builder = build_pex(reqs, options)
 

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -16,6 +16,7 @@ from textwrap import TextWrapper
 from pex.common import die, safe_delete, safe_mkdtemp
 from pex.interpreter import PythonInterpreter
 from pex.interpreter_constraints import validate_constraints
+from pex.jobs import DEFAULT_MAX_JOBS
 from pex.pex import PEX
 from pex.pex_bootstrapper import iter_compatible_interpreters
 from pex.pex_builder import PEXBuilder
@@ -188,6 +189,17 @@ def configure_clp_pex_resolution(parser):
     action='callback',
     callback=process_transitive,
     help='Whether to transitively resolve requirements. Default: True')
+
+  group.add_option(
+    '-j', '--jobs',
+    metavar='JOBS',
+    dest='max_parallel_jobs',
+    type=int,
+    default=DEFAULT_MAX_JOBS,
+    help='The maximum number of parallel jobs to use when resolving, building and installing '
+         'distributions. You might want to increase the maximum number of parallel jobs to '
+         'potentially improve the latency of the pex creation process at the expense of other'
+         'processes on your system. [Default: %default]')
 
   parser.add_option_group(group)
 
@@ -552,7 +564,8 @@ def build_pex(reqs, options):
                                 cache=options.cache_dir,
                                 build=options.build,
                                 use_wheel=options.use_wheel,
-                                compile=options.compile)
+                                compile=options.compile,
+                                max_parallel_jobs=options.max_parallel_jobs)
 
       for resolved_dist in resolveds:
         log('  %s -> %s' % (resolved_dist.requirement, resolved_dist.distribution),

--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -102,4 +102,20 @@ else:
   from urllib import pathname2url, url2pathname
 
 
+if PY3:
+  from queue import Queue
+
+  # The `os.sched_getaffinity` function appears to be supported on Linux but not OSX.
+  if not hasattr(os, 'sched_getaffinity'):
+    from os import cpu_count
+  else:
+    def cpu_count():
+      # The set of CPUs accessible to the current process (pid 0).
+      cpu_set = os.sched_getaffinity(0)
+      return len(cpu_set)
+else:
+  from Queue import Queue
+  from multiprocessing import cpu_count
+
+
 WINDOWS = os.name == 'nt'

--- a/pex/distribution_target.py
+++ b/pex/distribution_target.py
@@ -1,0 +1,70 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from pex.interpreter import PythonInterpreter
+from pex.platforms import Platform
+
+
+class DistributionTarget(object):
+  """Represents the target of a python distribution."""
+
+  @classmethod
+  def current(cls):
+    return cls(interpreter=None, platform=None)
+
+  @classmethod
+  def for_interpreter(cls, interpreter):
+    return cls(interpreter=interpreter, platform=None)
+
+  @classmethod
+  def for_platform(cls, platform):
+    return cls(interpreter=None, platform=platform)
+
+  def __init__(self, interpreter=None, platform=None):
+    self._interpreter = interpreter
+    self._platform = platform
+
+  @property
+  def is_foreign(self):
+    if self._platform is None:
+      return False
+    return self._platform != Platform.of_interpreter(self._interpreter)
+
+  def get_interpreter(self):
+    return self._interpreter or PythonInterpreter.get()
+
+  def get_platform(self):
+    return self._platform or Platform.current()
+
+  @property
+  def id(self):
+    """A unique id for a resolve target suitable as a path name component.
+
+    :rtype: str
+    """
+    if self._platform is None:
+      interpreter = self.get_interpreter()
+      return '{impl}-{ver}-{abi}'.format(impl=interpreter.identity.abbr_impl,
+                                         ver=interpreter.identity.impl_ver,
+                                         abi=interpreter.identity.abi_tag)
+    else:
+      return str(self._platform)
+
+  def __repr__(self):
+    if self._platform is None:
+      return 'Target(interpreter={!r})'.format(self.get_interpreter())
+    else:
+      return 'Target(platform={!r})'.format(self._platform)
+
+  def _tup(self):
+    return self._interpreter, self._platform
+
+  def __eq__(self, other):
+    if type(other) is not type(self):
+      return NotImplemented
+    return self._tup() == other._tup()
+
+  def __hash__(self):
+    return hash(self._tup())

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -318,6 +318,7 @@ class PythonInterpreter(object):
     cmd.append('-s')
 
     env = cls.sanitized_environment(env=env)
+    pythonpath = list(pythonpath or ())
     if pythonpath:
       env['PYTHONPATH'] = os.pathsep.join(pythonpath)
     else:

--- a/pex/jobs.py
+++ b/pex/jobs.py
@@ -1,0 +1,243 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import errno
+import os
+from threading import BoundedSemaphore, Event, Thread
+
+from pex import third_party
+from pex.compatibility import Queue, cpu_count
+from pex.interpreter import PythonInterpreter
+from pex.tracer import TRACER
+
+
+class Job(object):
+  """Represents a job spawned as a subprocess.
+
+  Presents a similar API to `subprocess` except where noted.
+  """
+
+  class Error(Exception):
+    """Indicates that a Job exited non-zero."""
+
+  def __init__(self, command, process):
+    """
+    :param command: The command used to spawn the job process.
+    :type command: list of str
+    :param process: The spawned process handle.
+    :type process: :class:`subprocess.Popen`
+    """
+    self._command = command
+    self._process = process
+
+  def wait(self):
+    """Waits for the job to complete.
+
+    :raises: :class:`Job.Error` if the job exited non-zero.
+    """
+    self._process.wait()
+    self._check_returncode()
+
+  def communicate(self, input=None):
+    """Communicates with the job sending any input data to stdin and collecting stdout and stderr.
+
+    :param input: Data to send to stdin of the job as per the `subprocess` API.
+    :return: A tuple of the job's stdout and stderr as per the `subprocess` API.
+    :raises: :class:`Job.Error` if the job exited non-zero.
+    """
+    stdout, stderr = self._process.communicate(input=input)
+    self._check_returncode()
+    return stdout, stderr
+
+  def kill(self):
+    """Terminates the job if it is still running.
+
+    N.B.: This method is idempotent.
+    """
+    try:
+      self._process.kill()
+    except OSError as e:
+      if e.errno != errno.ESRCH:
+        raise e
+
+  def _check_returncode(self):
+    if self._process.returncode != 0:
+      raise self.Error('Executing {} failed with {}'
+                       .format(' '.join(self._command), self._process.returncode))
+
+  def __str__(self):
+    return 'pid: {pid} -> {command}'.format(pid=self._process.pid, command=' '.join(self._command))
+
+
+def spawn_python_job(args, env=None, interpreter=None, expose=None, **subprocess_kwargs):
+  """Spawns a python job.
+
+  :param args: The arguments to pass to the python interpreter.
+  :type args: list of str
+  :param env: The environment to spawn the python interpreter process in. Defaults to the ambient
+              environment.
+  :type env: dict of (str, str)
+  :param interpreter: The interpreter to use to spawn the python job. Defaults to the current
+                      interpreter.
+  :type interpreter: :class:`PythonInterpreter`
+  :param expose: The names of any vendored distributions to expose to the spawned python process.
+  :type expose: list of str
+  :param subprocess_kwargs: Any additional :class:`subprocess.Popen` kwargs to pass through.
+  :returns: A job handle to the spawned python process.
+  :rtype: :class:`Job`
+  """
+  if expose:
+    subprocess_env = (env or os.environ).copy()
+    # In order to expose vendored distributions with their un-vendored import paths in-tact, we
+    # need to set `__PEX_UNVENDORED__`. See: vendor.__main__.ImportRewriter._modify_import.
+    subprocess_env['__PEX_UNVENDORED__'] = '1'
+
+    pythonpath = third_party.expose(expose)
+  else:
+    subprocess_env = env
+    pythonpath = None
+
+  interpreter = interpreter or PythonInterpreter.get()
+  cmd, process = interpreter.open_process(
+    args=args,
+    pythonpath=pythonpath,
+    env=subprocess_env,
+    **subprocess_kwargs
+  )
+  return Job(command=cmd, process=process)
+
+
+class SpawnedJob(object):
+  """A handle to a spawned :class:`Job` and its associated result."""
+
+  @classmethod
+  def wait(cls, job, result):
+    """Wait for the job to complete and return a fixed result upon success.
+
+    :param job: The spawned job.
+    :type job: :class:`Job`
+    :param result: The fixed success result.
+    :return: A spawned job whose result is a side effect of the job (a written file, a populated
+             directory, etc.).
+    :rtype: :class:`SpawnedJob`
+    """
+    def wait_result_func():
+      job.wait()
+      return result
+
+    return cls(job=job, result_func=wait_result_func)
+
+  @classmethod
+  def stdout(cls, job, result_func, input=None):
+    """Wait for the job to complete and return a result derived from its stdout.
+
+    :param job: The spawned job.
+    :type job: :class:`Job`
+    :param result_func: A function taking the stdout byte string collected from the spawned job and
+                        returning the desired result.
+    :param input: Optional input stream data to pass to the process as per the
+                  `subprocess.Popen.communicate` API.
+    :return: A spawned job whose result is derived from stdout contents.
+    :rtype: :class:`SpawnedJob`
+    """
+    def stdout_result_func():
+      stdout, _ = job.communicate(input=input)
+      return result_func(stdout)
+
+    return cls(job=job, result_func=stdout_result_func)
+
+  def __init__(self, job, result_func):
+    """Not intended for direct use, see `wait` and `stdout` factories."""
+    self._job = job
+    self._result_func = result_func
+
+  def await_result(self):
+    """Waits for the spawned job to complete and returns its result."""
+    return self._result_func()
+
+  def kill(self):
+    """Terminates the spawned job if it's not already complete."""
+    self._job.kill()
+
+  def __str__(self):
+    return str(self._job)
+
+
+_CPU_COUNT = cpu_count()
+_ABSOLUTE_MAX_JOBS = _CPU_COUNT * 2
+
+
+DEFAULT_MAX_JOBS = _CPU_COUNT
+"""The default maximum number of parallel jobs PEX should use."""
+
+
+def _sanitize_max_jobs(max_jobs=None):
+  assert max_jobs is None or isinstance(max_jobs, int)
+  if max_jobs is None or max_jobs <= 0:
+    return DEFAULT_MAX_JOBS
+  else:
+    return min(max_jobs, _ABSOLUTE_MAX_JOBS)
+
+
+def execute_parallel(max_jobs, inputs, spawn_func, raise_type):
+  """Execute jobs for the given inputs in parallel.
+
+  :param int max_jobs: The maximum number of parallel jobs to spawn.
+  :param inputs: An iterable of the data to parallelize over `spawn_func`.
+  :param spawn_func: A function taking a single input and returning a :class:`SpawnedJob`.
+  :param raise_type: A type that takes a single string argument and will be used to construct a
+                     raiseable value when any of the spawned jobs errors.
+  :returns: An iterator over the spawned job results as they come in.
+  :raises: A `raise_type` exception if any individual job errors.
+  """
+  size = _sanitize_max_jobs(max_jobs)
+  TRACER.log('Spawning a maximum of {} parallel jobs to process:\n  {}'
+             .format(size, '\n  '.join(map(str, inputs))),
+             V=9)
+
+  stop = Event()  # Used as a signal to stop spawning further jobs once any one job fails.
+  job_slots = BoundedSemaphore(value=size)
+  done_sentinel = object()
+  spawned_job_queue = Queue()  # Queue[Union[SpawnedJob, Exception, Literal[done_sentinel]]]
+
+  def spawn_jobs():
+    for item in inputs:
+      if stop.is_set():
+        break
+      job_slots.acquire()
+      try:
+        resut = spawn_func(item)
+      except Exception as e:
+        resut = e
+      finally:
+        spawned_job_queue.put(resut)
+    spawned_job_queue.put(done_sentinel)
+
+  spawner = Thread(name='PEX Parallel Job Spawner', target=spawn_jobs)
+  spawner.daemon = True
+  spawner.start()
+
+  error = None
+  while True:
+    item = spawned_job_queue.get()
+
+    if item is done_sentinel:
+      if error:
+        raise error
+      return
+
+    try:
+      if isinstance(item, Exception):
+        error = item
+      elif error is not None:  # I.E.: `item` is not an exception, but there was a prior exception.
+        item.kill()
+      else:
+        try:
+          yield item.await_result()
+        except Job.Error as e:
+          stop.set()
+          error = raise_type('{} raised {}'.format(item, e))
+    finally:
+      job_slots.release()

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -305,7 +305,7 @@ class PEXBuilder(object):
     elif dist.location.endswith('.whl'):
       dist_hash = self._add_dist_wheel_file(dist.location, dist_name)
     else:
-      raise self.InvalidDistribution('Unsupported distribution type: {}'.format(dist))
+      raise self.InvalidDistribution('Unsupported distribution type: {}. pex can accept dist dirs and wheels.'.format(dist))
 
     # add dependency key so that it can rapidly be retrieved from cache
     self._pex_info.add_distribution(dist_name, dist_hash)

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -9,10 +9,11 @@ import os
 from pex.common import Chroot, chmod_plus_x, open_zip, safe_mkdir, safe_mkdtemp
 from pex.compatibility import to_bytes
 from pex.compiler import Compiler
+from pex.distribution_target import DistributionTarget
 from pex.finders import get_entry_point_from_console_script, get_script_from_distributions
 from pex.interpreter import PythonInterpreter
 from pex.pex_info import PexInfo
-from pex.pip import install_wheel
+from pex.pip import spawn_install_wheel
 from pex.third_party.pkg_resources import DefaultProvider, ZipProvider, get_provider
 from pex.tracer import TRACER
 from pex.util import CacheHelper, DistributionHelper
@@ -285,7 +286,12 @@ class PEXBuilder(object):
       tmp = safe_mkdtemp()
       whltmp = os.path.join(tmp, dist_name)
       os.mkdir(whltmp)
-      install_wheel(wheel=path, target=whltmp, overwrite=True, interpreter=self.interpreter)
+      install_job = spawn_install_wheel(
+        wheel=path,
+        install_dir=whltmp,
+        target=DistributionTarget.for_interpreter(self.interpreter)
+      )
+      install_job.wait()
       for root, _, files in os.walk(whltmp):
         pruned_dir = os.path.relpath(root, tmp)
         for f in files:

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -305,7 +305,8 @@ class PEXBuilder(object):
     elif dist.location.endswith('.whl'):
       dist_hash = self._add_dist_wheel_file(dist.location, dist_name)
     else:
-      raise self.InvalidDistribution('Unsupported distribution type: {}. pex can accept dist dirs and wheels.'.format(dist))
+      raise self.InvalidDistribution('Unsupported distribution type: {}, pex can only accept dist '
+                                     'dirs and wheels.'.format(dist))
 
     # add dependency key so that it can rapidly be retrieved from cache
     self._pex_info.add_distribution(dist_name, dist_hash)

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -11,6 +11,7 @@ from pex.common import open_zip
 from pex.compatibility import PY2
 from pex.compatibility import string as compatibility_string
 from pex.orderedset import OrderedSet
+from pex.util import CacheHelper
 from pex.variables import ENV
 from pex.version import __version__ as pex_version
 
@@ -46,7 +47,7 @@ class PexInfo(object):
   """
 
   PATH = 'PEX-INFO'
-  INTERNAL_CACHE = '.deps'
+  INSTALL_CACHE = 'installed_wheels'
 
   @classmethod
   def make_build_properties(cls, interpreter=None):
@@ -290,11 +291,11 @@ class PexInfo(object):
 
   @property
   def internal_cache(self):
-    return self.INTERNAL_CACHE
+    return '.deps'
 
   @property
   def install_cache(self):
-    return os.path.join(self.pex_root, 'install')
+    return os.path.join(self.pex_root, self.INSTALL_CACHE)
 
   @property
   def zip_unsafe_cache(self):

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -11,7 +11,6 @@ from pex.common import open_zip
 from pex.compatibility import PY2
 from pex.compatibility import string as compatibility_string
 from pex.orderedset import OrderedSet
-from pex.util import CacheHelper
 from pex.variables import ENV
 from pex.version import __version__ as pex_version
 

--- a/pex/pip.py
+++ b/pex/pip.py
@@ -4,27 +4,16 @@
 
 from __future__ import absolute_import, print_function
 
-import os
 from collections import deque
 
-from pex import third_party
 from pex.compatibility import urlparse
-from pex.interpreter import PythonInterpreter
-from pex.platforms import Platform
+from pex.distribution_target import DistributionTarget
+from pex.jobs import spawn_python_job
 from pex.variables import ENV
 
 
-class PipError(Exception):
-  """Indicates an error running a pip command."""
-
-
-def execute_pip_isolated(args, cache=None, interpreter=None):
-  env = os.environ.copy()
-  env['__PEX_UNVENDORED__'] = '1'
-
-  pythonpath = third_party.expose(['pip', 'setuptools', 'wheel'])
-
-  pip_args = ['-m', 'pip', '--disable-pip-version-check', '--isolated']
+def _spawn_pip_isolated(args, cache=None, interpreter=None):
+  pip_args = ['-m', 'pip', '--disable-pip-version-check', '--isolated', '--exists-action', 'i']
 
   # The max pip verbosity is -vvv and for pex it's -vvvvvvvvv; so we scale down by a factor of 3.
   verbosity = ENV.PEX_VERBOSE // 3
@@ -38,12 +27,11 @@ def execute_pip_isolated(args, cache=None, interpreter=None):
   else:
     pip_args.append('--no-cache-dir')
 
-  pip_cmd = pip_args + args
-
-  interpreter = interpreter or PythonInterpreter.get()
-  cmd, process = interpreter.open_process(args=pip_cmd, pythonpath=pythonpath, env=env)
-  if process.wait() != 0:
-    raise PipError('Executing {} failed with {}'.format(' '.join(cmd), process.returncode))
+  return spawn_python_job(
+    args=pip_args + args,
+    interpreter=interpreter,
+    expose=['pip', 'setuptools', 'wheel']
+  )
 
 
 def _calculate_package_index_options(indexes=None, find_links=None):
@@ -80,33 +68,34 @@ def _calculate_package_index_options(indexes=None, find_links=None):
     yield trusted_host
 
 
-def download_distributions(target,
-                           requirements=None,
-                           requirement_files=None,
-                           constraint_files=None,
-                           allow_prereleases=False,
-                           transitive=True,
-                           interpreter=None,
-                           platform=None,
-                           indexes=None,
-                           find_links=None,
-                           cache=None,
-                           build=True,
-                           use_wheel=True):
+def spawn_download_distributions(download_dir,
+                                 requirements=None,
+                                 requirement_files=None,
+                                 constraint_files=None,
+                                 allow_prereleases=False,
+                                 transitive=True,
+                                 target=None,
+                                 indexes=None,
+                                 find_links=None,
+                                 cache=None,
+                                 build=True,
+                                 use_wheel=True):
 
-  foreign_platform = (platform != Platform.of_interpreter(interpreter)) if platform else False
+  target = target or DistributionTarget.current()
+
+  platform = target.get_platform()
   if not use_wheel:
     if not build:
-      raise PipError('Cannot both ignore wheels (use_wheel=False) and refrain from building '
-                     'distributions (build=False).')
-    elif foreign_platform:
-      raise PipError('Cannot ignore wheels (use_wheel=False) when resolving for a foreign '
-                     'platform: {}'.format(platform))
+      raise ValueError('Cannot both ignore wheels (use_wheel=False) and refrain from building '
+                       'distributions (build=False).')
+    elif target.is_foreign:
+      raise ValueError('Cannot ignore wheels (use_wheel=False) when resolving for a foreign '
+                       'platform: {}'.format(platform))
 
-  download_cmd = ['download', '--dest', target]
+  download_cmd = ['download', '--dest', download_dir]
   download_cmd.extend(_calculate_package_index_options(indexes=indexes, find_links=find_links))
 
-  if foreign_platform:
+  if target.is_foreign:
     # We're either resolving for a different host / platform or a different interpreter for the
     # current platform that we have no access to; so we need to let pip know and not otherwise
     # pickup platform info from the interpreter we execute pip with.
@@ -115,7 +104,7 @@ def download_distributions(target,
     download_cmd.extend(['--python-version', platform.version])
     download_cmd.extend(['--abi', platform.abi])
 
-  if foreign_platform or not build:
+  if target.is_foreign or not build:
     download_cmd.extend(['--only-binary', ':all:'])
 
   if not use_wheel:
@@ -137,28 +126,54 @@ def download_distributions(target,
 
   download_cmd.extend(requirements)
 
-  execute_pip_isolated(download_cmd, cache=cache, interpreter=interpreter)
+  return _spawn_pip_isolated(download_cmd, cache=cache, interpreter=target.get_interpreter())
 
 
-def build_wheels(distributions,
-                 target,
-                 interpreter=None,
-                 indexes=None,
-                 find_links=None,
-                 cache=None):
-  wheel_cmd = ['wheel', '--no-deps', '--wheel-dir', target]
+def spawn_build_wheels(distributions,
+                       wheel_dir,
+                       interpreter=None,
+                       indexes=None,
+                       find_links=None,
+                       cache=None):
+
+  wheel_cmd = ['wheel', '--no-deps', '--wheel-dir', wheel_dir]
 
   # If the build is PEP-517 compliant it may need to resolve build requirements.
   wheel_cmd.extend(_calculate_package_index_options(indexes=indexes, find_links=find_links))
 
   wheel_cmd.extend(distributions)
-  execute_pip_isolated(wheel_cmd, cache=cache, interpreter=interpreter)
+  return _spawn_pip_isolated(wheel_cmd, cache=cache, interpreter=interpreter)
 
 
-def install_wheel(wheel, target, compile=False, overwrite=False, cache=None, interpreter=None):
-  install_cmd = ['install', '--no-deps', '--no-index', '--only-binary', ':all:', '--target', target]
+def spawn_install_wheel(wheel,
+                        install_dir,
+                        compile=False,
+                        overwrite=False,
+                        cache=None,
+                        target=None):
+
+  target = target or DistributionTarget.current()
+
+  install_cmd = [
+    'install',
+    '--no-deps',
+    '--no-index',
+    '--only-binary', ':all:',
+    '--target', install_dir
+  ]
+
+  interpreter = target.get_interpreter()
+  if target.is_foreign:
+    if compile:
+      raise ValueError('Cannot compile bytecode for {} using {} because the wheel has a foreign '
+                       'platform.'.format(wheel, interpreter))
+
+    # We're installing a wheel for a foreign platform. This is just an unpacking operation though;
+    # so we don't actually need to perform it with a target platform compatible interpreter.
+    install_cmd.append('--ignore-requires-python')
+
   install_cmd.append('--compile' if compile else '--no-compile')
   if overwrite:
     install_cmd.extend(['--upgrade', '--force-reinstall'])
   install_cmd.append(wheel)
-  execute_pip_isolated(install_cmd, cache=cache, interpreter=interpreter)
+  return _spawn_pip_isolated(install_cmd, cache=cache, interpreter=interpreter)

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -58,7 +58,7 @@ class Platform(namedtuple('Platform', ['platform', 'impl', 'version', 'abi'])):
       )
     platform = platform.replace('-', '_').replace('.', '_')
     abi = cls._maybe_prefix_abi(impl, version, abi)
-    return super(cls, Platform).__new__(cls, platform, impl, version, abi)
+    return super(Platform, cls).__new__(cls, platform, impl, version, abi)
 
   def __str__(self):
     return self.SEP.join(self)

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -3,23 +3,25 @@
 
 from __future__ import absolute_import
 
+import errno
 import functools
 import json
 import os
 import subprocess
-from collections import defaultdict, namedtuple
+from collections import OrderedDict, defaultdict, namedtuple
 from textwrap import dedent
 from uuid import uuid4
 
-from pex import third_party
 from pex.common import safe_mkdtemp
-from pex.interpreter import PythonInterpreter
+from pex.distribution_target import DistributionTarget
+from pex.jobs import SpawnedJob, execute_parallel, spawn_python_job
 from pex.orderedset import OrderedSet
-from pex.pip import PipError, build_wheels, download_distributions, install_wheel
+from pex.pip import spawn_build_wheels, spawn_download_distributions, spawn_install_wheel
 from pex.platforms import Platform
 from pex.requirements import local_project_from_requirement, local_projects_from_requirement_file
 from pex.third_party.pkg_resources import Distribution, Environment, Requirement
 from pex.tracer import TRACER
+from pex.util import CacheHelper
 
 
 class Untranslateable(Exception):
@@ -39,45 +41,74 @@ class ResolvedDistribution(namedtuple('ResolvedDistribution', ['requirement', 'd
     return super(ResolvedDistribution, cls).__new__(cls, requirement, distribution)
 
 
-def _calculate_dependency_markers(distributions, interpreter=None):
-  search_path = [dist.location for dist in distributions]
-  program = dedent("""
-    import json
-    import sys
-    from collections import defaultdict
-    from pkg_resources import Environment
-    
-    
-    env = Environment(search_path={search_path!r})
-    dependency_requirements = []
-    for key in env:
-      for dist in env[key]:
-        dependency_requirements.extend(str(req) for req in dist.requires())
-    json.dump(dependency_requirements, sys.stdout)
-  """.format(search_path=search_path))
+class DistributionRequirements(object):
+  class Request(namedtuple('DistributionRequirementsRequest', ['target', 'distributions'])):
+    def spawn_calculation(self):
+      search_path = [dist.location for dist in self.distributions]
 
-  env = os.environ.copy()
-  env['__PEX_UNVENDORED__'] = '1'
+      program = dedent("""
+        import json
+        import sys
+        from collections import defaultdict
+        from pkg_resources import Environment
 
-  pythonpath = third_party.expose(['setuptools'])
 
-  interpreter = interpreter or PythonInterpreter.get()
-  _, process = interpreter.open_process(args=['-c', program],
-                                        stdout=subprocess.PIPE,
-                                        pythonpath=pythonpath,
-                                        env=env)
-  stdout, _ = process.communicate()
-  if process.returncode != 0:
-    raise Untranslateable('Could not determine dependency environment markers for {}'
-                          .format(distributions))
+        env = Environment(search_path={search_path!r})
+        dependency_requirements = []
+        for key in env:
+          for dist in env[key]:
+            dependency_requirements.extend(str(req) for req in dist.requires())
+        json.dump(dependency_requirements, sys.stdout)
+      """.format(search_path=search_path))
 
-  dependency_requirements = json.loads(stdout.decode('utf-8'))
-  markers_by_req_key = defaultdict(OrderedSet)
-  for requirement in dependency_requirements:
-    req = Requirement.parse(requirement)
-    if req.marker:
-      markers_by_req_key[req.key].add(req.marker)
-  return markers_by_req_key
+      job = spawn_python_job(
+        args=['-c', program],
+        stdout=subprocess.PIPE,
+        interpreter=self.target.get_interpreter(),
+        expose=['setuptools']
+      )
+      return SpawnedJob.stdout(job=job, result_func=self._markers_by_requirement)
+
+    @staticmethod
+    def _markers_by_requirement(stdout):
+      dependency_requirements = json.loads(stdout.decode('utf-8'))
+      markers_by_req_key = defaultdict(OrderedSet)
+      for requirement in dependency_requirements:
+        req = Requirement.parse(requirement)
+        if req.marker:
+          markers_by_req_key[req.key].add(req.marker)
+      return markers_by_req_key
+
+  @classmethod
+  def merged(cls, markers_by_requirement_key_iter):
+    markers_by_requirement_key = defaultdict(OrderedSet)
+    for distribution_markers in markers_by_requirement_key_iter:
+      for requirement, markers in distribution_markers.items():
+        markers_by_requirement_key[requirement].update(markers)
+    return cls(markers_by_requirement_key)
+
+  def __init__(self, markers_by_requirement_key):
+    self._markers_by_requirement_key = markers_by_requirement_key
+
+  def to_requirement(self, dist):
+    req = dist.as_requirement()
+    markers = self._markers_by_requirement_key.get(req.key)
+    if not markers:
+      return req
+
+    if len(markers) == 1:
+      marker = next(iter(markers))
+      req.marker = marker
+      return req
+
+    # Here we have a resolve with multiple paths to the dependency represented by dist. At least
+    # two of those paths had (different) conditional requirements for dist based on environment
+    # marker predicates. Since the pip resolve succeeded, the implication is that the environment
+    # markers are compatible; i.e.: their intersection selects the target interpreter. Here we
+    # make that intersection explicit.
+    # See: https://www.python.org/dev/peps/pep-0496/#micro-language
+    marker = ' and '.join('({})'.format(marker) for marker in markers)
+    return Requirement.parse('{}; {}'.format(req, marker))
 
 
 def parsed_platform(platform=None):
@@ -95,6 +126,411 @@ def parsed_platform(platform=None):
   return Platform.create(platform) if platform and platform != 'current' else None
 
 
+class AtomicDirectory(namedtuple('AtomicDirectory', ['work_dir', 'target_dir'])):
+  @classmethod
+  def for_target_dir(cls, target_dir):
+    return cls(work_dir='{}.{}'.format(target_dir, uuid4().hex), target_dir=target_dir)
+
+  @property
+  def is_finalized(self):
+    return os.path.exists(self.target_dir)
+
+  def finalize(self):
+    if self.is_finalized:
+      return
+
+    try:
+      # Perform an atomic rename.
+      #
+      # Per the docs: https://docs.python.org/2.7/library/os.html#os.rename
+      #
+      #   The operation may fail on some Unix flavors if src and dst are on different filesystems.
+      #   If successful, the renaming will be an atomic operation (this is a POSIX requirement).
+      #
+      # We have satisfied the single filesystem constraint by arranging the `work_dir` to be a
+      # sibling of the `target_dir`.
+      os.rename(self.work_dir, self.target_dir)
+    except OSError as e:
+      if e.errno != errno.ENOTEMPTY:
+        raise e
+
+
+class ResolveResult(namedtuple('ResolveResult', ['target', 'download_dir'])):
+  @staticmethod
+  def _is_wheel(path):
+    return os.path.isfile(path) and path.endswith('.whl')
+
+  def _iter_distribution_paths(self):
+    if not os.path.exists(self.download_dir):
+      return
+    for distribution in os.listdir(self.download_dir):
+      yield os.path.join(self.download_dir, distribution)
+
+  def build_requests(self):
+    for distribution_path in self._iter_distribution_paths():
+      if not self._is_wheel(distribution_path):
+        yield BuildRequest.create(target=self.target, source_path=distribution_path)
+
+  def install_requests(self):
+    for distribution_path in self._iter_distribution_paths():
+      if self._is_wheel(distribution_path):
+        yield InstallRequest.create(target=self.target, wheel_path=distribution_path)
+
+
+class BuildRequest(namedtuple('BuildRequest', ['target', 'source_path', 'fingerprint'])):
+  @classmethod
+  def create(cls, target, source_path):
+    hasher = CacheHelper.dir_hash if os.path.isdir(source_path) else CacheHelper.hash
+    fingerprint = hasher(source_path)
+    return cls(target=target, source_path=source_path, fingerprint=fingerprint)
+
+  def result(self, dist_root):
+    return BuildResult.from_request(self, dist_root=dist_root)
+
+
+class BuildResult(namedtuple('BuildResult', ['request', 'atomic_dir'])):
+  @classmethod
+  def from_request(cls, build_request, dist_root):
+    dist_dir = os.path.join(
+      dist_root,
+      'sdists' if os.path.isfile(build_request.source_path) else 'local_projects',
+      os.path.basename(build_request.source_path),
+      build_request.fingerprint,
+      build_request.target.id
+    )
+    return cls(request=build_request, atomic_dir=AtomicDirectory.for_target_dir(dist_dir))
+
+  @property
+  def is_built(self):
+    return self.atomic_dir.is_finalized
+
+  @property
+  def build_dir(self):
+    return self.atomic_dir.work_dir
+
+  @property
+  def dist_dir(self):
+    return self.atomic_dir.target_dir
+
+  def finalize_build(self):
+    self.atomic_dir.finalize()
+    for wheel in os.listdir(self.dist_dir):
+      yield InstallRequest.create(self.request.target, os.path.join(self.dist_dir, wheel))
+
+
+class InstallRequest(namedtuple('InstallRequest', ['target', 'wheel_path', 'fingerprint'])):
+  @classmethod
+  def create(cls, target, wheel_path):
+    fingerprint = CacheHelper.hash(wheel_path)
+    return cls(target=target, wheel_path=wheel_path, fingerprint=fingerprint)
+
+  @property
+  def wheel_file(self):
+    return os.path.basename(self.wheel_path)
+
+  def result(self, installation_root):
+    return InstallResult.from_request(self, installation_root=installation_root)
+
+
+class InstallResult(namedtuple('InstallResult', ['request', 'atomic_dir'])):
+  @classmethod
+  def from_request(cls, install_request, installation_root):
+    install_chroot = os.path.join(
+      installation_root,
+      install_request.fingerprint,
+      install_request.wheel_file
+    )
+    return cls(request=install_request, atomic_dir=AtomicDirectory.for_target_dir(install_chroot))
+
+  @property
+  def is_installed(self):
+    return self.atomic_dir.is_finalized
+
+  @property
+  def build_chroot(self):
+    return self.atomic_dir.work_dir
+
+  @property
+  def install_chroot(self):
+    return self.atomic_dir.target_dir
+
+  def finalize_install(self, install_requests):
+    self.atomic_dir.finalize()
+    return self._iter_requirements_requests(install_requests)
+
+  def _iter_requirements_requests(self, install_requests):
+    if self.is_installed:
+      # N.B.: Direct snip from the Environment docs:
+      #
+      #  You may explicitly set `platform` (and/or `python`) to ``None`` if you
+      #  wish to map *all* distributions, not just those compatible with the
+      #  running platform or Python version.
+      #
+      # Since our requested target may be foreign, we make sure find all distributions installed by
+      # explicitly setting both `python` and `platform` to `None`.
+      environment = Environment(search_path=[self.install_chroot], python=None, platform=None)
+
+      distributions = []
+      for dist_project_name in environment:
+        distributions.extend(environment[dist_project_name])
+
+      for install_request in install_requests:
+        yield DistributionRequirements.Request(
+          target=install_request.target,
+          distributions=distributions
+        )
+
+
+class ResolveRequest(object):
+  def __init__(self,
+               targets,
+               requirements=None,
+               requirement_files=None,
+               constraint_files=None,
+               allow_prereleases=False,
+               transitive=True,
+               indexes=None,
+               find_links=None,
+               cache=None,
+               build=True,
+               use_wheel=True,
+               compile=False,
+               max_parallel_jobs=None):
+
+    self._targets = targets
+    self._requirements = requirements
+    self._requirement_files = requirement_files
+    self._constraint_files = constraint_files
+    self._allow_prereleases = allow_prereleases
+    self._transitive = transitive
+    self._indexes = indexes
+    self._find_links = find_links
+    self._cache = cache
+    self._build = build
+    self._use_wheel = use_wheel
+    self._compile = compile
+    self._max_parallel_jobs = max_parallel_jobs
+
+  def _iter_local_projects(self):
+    if self._requirements:
+      for req in self._requirements:
+        local_project = local_project_from_requirement(req)
+        if local_project:
+          for target in self._targets:
+            yield BuildRequest.create(target=target, source_path=local_project)
+
+    if self._requirement_files:
+      for requirement_file in self._requirement_files:
+        for local_project in local_projects_from_requirement_file(requirement_file):
+          for target in self._targets:
+            yield BuildRequest.create(target=target, source_path=local_project)
+
+  def _run_parallel(self, inputs, spawn_func, raise_type):
+    for result in execute_parallel(self._max_parallel_jobs, inputs, spawn_func, raise_type):
+      yield result
+
+  def _spawn_resolve(self, resolved_dists_dir, target):
+    download_dir = os.path.join(resolved_dists_dir, target.id)
+    download_job = spawn_download_distributions(
+      download_dir=download_dir,
+      requirements=self._requirements,
+      requirement_files=self._requirement_files,
+      constraint_files=self._constraint_files,
+      allow_prereleases=self._allow_prereleases,
+      transitive=self._transitive,
+      target=target,
+      indexes=self._indexes,
+      find_links=self._find_links,
+      cache=self._cache,
+      build=self._build,
+      use_wheel=self._use_wheel
+    )
+    return SpawnedJob.wait(job=download_job, result=ResolveResult(target, download_dir))
+
+  def _categorize_build_requests(self, build_requests, dist_root):
+    unsatisfied_build_requests = []
+    install_requests = []
+    for build_request in build_requests:
+      build_result = build_request.result(dist_root)
+      if not build_result.is_built:
+        TRACER.log('Building {} to {}'.format(build_request.source_path, build_result.dist_dir))
+        unsatisfied_build_requests.append(build_request)
+      else:
+        TRACER.log('Using cached build of {} at {}'
+                   .format(build_request.source_path, build_result.dist_dir))
+        install_requests.extend(build_result.finalize_build())
+    return unsatisfied_build_requests, install_requests
+
+  def _spawn_wheel_build(self, built_wheels_dir, build_request):
+    build_result = build_request.result(built_wheels_dir)
+    build_job = spawn_build_wheels(
+      distributions=[build_request.source_path],
+      wheel_dir=build_result.build_dir,
+      cache=self._cache,
+      interpreter=build_request.target.get_interpreter()
+    )
+    return SpawnedJob.wait(job=build_job, result=build_result)
+
+  def _categorize_install_requests(self, install_requests, installed_wheels_dir):
+    unsatisfied_install_requests = []
+    install_results = []
+    for install_request in install_requests:
+      install_result = install_request.result(installed_wheels_dir)
+      if not install_result.is_installed:
+        TRACER.log('Installing {} in {}'
+                   .format(install_request.wheel_path, install_result.install_chroot))
+        unsatisfied_install_requests.append(install_request)
+      else:
+        TRACER.log('Using cached installation of {} at {}'
+                   .format(install_request.wheel_file, install_result.install_chroot))
+        install_results.append(install_result)
+    return unsatisfied_install_requests, install_results
+
+  def _spawn_install(self, installed_wheels_dir, install_request):
+    install_result = install_request.result(installed_wheels_dir)
+    install_job = spawn_install_wheel(
+      wheel=install_request.wheel_path,
+      install_dir=install_result.build_chroot,
+      compile=self._compile,
+      overwrite=True,
+      cache=self._cache,
+      target=install_request.target
+    )
+    return SpawnedJob.wait(job=install_job, result=install_result)
+
+  def resolve_distributions(self):
+    # This method has four stages:
+    # 1. Resolve sdists and wheels.
+    # 2. Build local projects and sdists.
+    # 3. Install wheels in individual chroots.
+    # 4. Calculate the final resolved requirements.
+    #
+    # You'd think we might be able to just pip install all the requirements, but pexes can be
+    # multi-platform / multi-interpreter, in which case only a subset of distributions resolved into
+    # the PEX should be activated for the runtime interpreter. Sometimes there are platform specific
+    # wheels and sometimes python version specific dists (backports being the common case). As such,
+    # we need to be able to add each resolved distribution to the `sys.path` individually
+    # (`PEXEnvironment` handles this selective activation at runtime). Since pip install only
+    # accepts a single location to install all resolved dists, that won't work.
+    #
+    # This means we need to separately resolve all distributions, then install each in their own
+    # chroot. To do this we use `pip download` for the resolve and download of all needed
+    # distributions and then `pip install` to install each distribution in its own chroot.
+    #
+    # As a complicating factor, the runtime activation scheme relies on PEP 425 tags; i.e.: wheel
+    # names. Some requirements are only available or applicable in source form - either via sdist,
+    # VCS URL or local projects. As such we need to insert a `pip wheel` step to generate wheels for
+    # all requirements resolved in source form via `pip download` / inspection of requirements to
+    # discover those that are local directories (local setup.py or pyproject.toml python projects).
+    #
+    # Finally, we must calculate the pinned requirement corresponding to each distribution we
+    # resolved along with any environment markers that control which runtime environments the
+    # requirement should be activated in.
+
+    if not self._requirements and not self._requirement_files:
+      # Nothing to resolve.
+      return []
+
+    workspace = safe_mkdtemp()
+    cache = self._cache or workspace
+
+    resolved_dists_dir = os.path.join(workspace, 'resolved_dists')
+    spawn_resolve = functools.partial(self._spawn_resolve, resolved_dists_dir)
+    to_resolve = self._targets
+
+    built_wheels_dir = os.path.join(cache, 'built_wheels')
+    spawn_wheel_build = functools.partial(self._spawn_wheel_build, built_wheels_dir)
+    to_build = list(self._iter_local_projects())
+
+    installed_wheels_dir = os.path.join(cache, 'installed_wheels')
+    spawn_install = functools.partial(self._spawn_install, installed_wheels_dir)
+    to_install = []
+
+    to_calculate_requirements_for = []
+
+    # 1. Resolve sdists and wheels.
+    with TRACER.timed('Resolving for:\n  '.format('\n  '.join(map(str, to_resolve)))):
+      for resolve_result in self._run_parallel(inputs=to_resolve,
+                                               spawn_func=spawn_resolve,
+                                               raise_type=Unsatisfiable):
+        to_build.extend(resolve_result.build_requests())
+        to_install.extend(resolve_result.install_requests())
+
+    if not any((to_build, to_install)):
+      # Nothing to build or install.
+      return []
+
+    # 2. Build local projects and sdists.
+    if to_build:
+      with TRACER.timed('Building distributions for:\n  {}'
+                        .format('\n  '.join(map(str, to_build)))):
+
+        build_requests, install_requests = self._categorize_build_requests(
+          build_requests=to_build,
+          dist_root=built_wheels_dir
+        )
+        to_install.extend(install_requests)
+
+        for build_result in self._run_parallel(inputs=build_requests,
+                                               spawn_func=spawn_wheel_build,
+                                               raise_type=Untranslateable):
+          to_install.extend(build_result.finalize_build())
+
+    # 3. Install wheels in individual chroots.
+
+    # Dedup by wheel name; e.g.: only install universal wheels once even though they'll get
+    # downloaded / built for each interpreter or platform.
+    install_requests_by_wheel_file = OrderedDict()
+    for install_request in to_install:
+      install_requests = install_requests_by_wheel_file.setdefault(install_request.wheel_file, [])
+      install_requests.append(install_request)
+
+    representative_install_requests = [
+      requests[0] for requests in install_requests_by_wheel_file.values()
+    ]
+
+    def add_requirements_requests(install_result):
+      install_requests = install_requests_by_wheel_file[install_result.request.wheel_file]
+      to_calculate_requirements_for.extend(install_result.finalize_install(install_requests))
+
+    with TRACER.timed('Installing:\n  {}'
+                      .format('\n  '.join(map(str, representative_install_requests)))):
+
+      install_requests, install_results = self._categorize_install_requests(
+        install_requests=representative_install_requests,
+        installed_wheels_dir=installed_wheels_dir
+      )
+      for install_result in install_results:
+        add_requirements_requests(install_result)
+
+      for install_result in self._run_parallel(inputs=install_requests,
+                                               spawn_func=spawn_install,
+                                               raise_type=Untranslateable):
+        add_requirements_requests(install_result)
+
+    # 4. Calculate the final resolved requirements.
+    with TRACER.timed('Calculating resolved requirements for:\n  {}'
+                      .format('\n  '.join(map(str, to_calculate_requirements_for)))):
+      distribution_requirements = DistributionRequirements.merged(
+        self._run_parallel(
+          inputs=to_calculate_requirements_for,
+          spawn_func=DistributionRequirements.Request.spawn_calculation,
+          raise_type=Untranslateable
+        )
+      )
+
+    resolved_distributions = OrderedSet()
+    for requirements_request in to_calculate_requirements_for:
+      for distribution in requirements_request.distributions:
+        resolved_distributions.add(
+          ResolvedDistribution(
+            requirement=distribution_requirements.to_requirement(distribution),
+            distribution=distribution
+          )
+        )
+    return resolved_distributions
+
+
 def resolve(requirements=None,
             requirement_files=None,
             constraint_files=None,
@@ -107,7 +543,8 @@ def resolve(requirements=None,
             cache=None,
             build=True,
             use_wheel=True,
-            compile=False):
+            compile=False,
+            max_parallel_jobs=None):
   """Produce all distributions needed to meet all specified requirements.
 
   :keyword requirements: A sequence of requirement strings.
@@ -141,152 +578,31 @@ def resolve(requirements=None,
     Defaults to ``True``.
   :keyword bool compile: Whether to pre-compile resolved distribution python sources.
     Defaults to ``False``.
+  :keyword int max_parallel_jobs: The maximum number of parallel jobs to use when resolving,
+    building and installing distributions in a resolve. Defaults to the number of CPUs available.
   :returns: List of :class:`ResolvedDistribution` instances meeting ``requirements``.
   :raises Unsatisfiable: If ``requirements`` is not transitively satisfiable.
   :raises Untranslateable: If no compatible distributions could be acquired for
     a particular requirement.
   """
 
-  # This function has three stages: 1) resolve, 2) build, and 3) chroot.
-  #
-  # You'd think we might be able to just pip install all the requirements, but pexes can be
-  # multi-platform / multi-interpreter, in which case only a subset of distributions resolved into
-  # the PEX should be activated for the runtime interpreter. Sometimes there are platform specific
-  # wheels and sometimes python version specific dists (backports being the common case). As such,
-  # we need to be able to add each resolved distribution to the `sys.path` individually
-  # (`PEXEnvironment` handles this selective activation at runtime). Since pip install only accepts
-  # a single location to install all resolved dists, that won't work.
-  #
-  # This means we need to seperately resolve all distributions, then install each in their own
-  # chroot. To do this we use `pip download` for the resolve and download of all needed
-  # distributions and then `pip install` to install each distribution in its own chroot.
-  #
-  # As a complicating factor, the runtime activation scheme relies on PEP 425 tags; i.e.: wheel
-  # names. Some requirements are only available or applicable in source form - either via sdist, VCS
-  # URL or local projects. As such we need to insert a `pip wheel` step to generate wheels for all
-  # requirements resolved in source form via `pip download` / inspection of requirements to
-  # discover those that are local directories (local setup.py or pyproject.toml python projects).
+  target = DistributionTarget(interpreter=interpreter, platform=parsed_platform(platform))
 
-  if not requirements and not requirement_files:
-    # Nothing to resolve.
-    return []
+  resolve_request = ResolveRequest(targets=[target],
+                                   requirements=requirements,
+                                   requirement_files=requirement_files,
+                                   constraint_files=constraint_files,
+                                   allow_prereleases=allow_prereleases,
+                                   transitive=transitive,
+                                   indexes=indexes,
+                                   find_links=find_links,
+                                   cache=cache,
+                                   build=build,
+                                   use_wheel=use_wheel,
+                                   compile=compile,
+                                   max_parallel_jobs=max_parallel_jobs)
 
-  workspace = safe_mkdtemp()
-  cache = cache or workspace
-  resolved_dists = os.path.join(workspace, 'resolved')
-  built_wheels = os.path.join(workspace, 'wheels')
-  installed_chroots = os.path.join(cache, 'chroots')
-
-  # 1. Resolve
-  with TRACER.timed('Resolving and downloading distributions'):
-    try:
-      download_distributions(target=resolved_dists,
-                             requirements=requirements,
-                             requirement_files=requirement_files,
-                             constraint_files=constraint_files,
-                             allow_prereleases=allow_prereleases,
-                             transitive=transitive,
-                             interpreter=interpreter,
-                             platform=parsed_platform(platform),
-                             indexes=indexes,
-                             find_links=find_links,
-                             cache=cache,
-                             build=build,
-                             use_wheel=use_wheel)
-    except PipError as e:
-      raise Unsatisfiable(str(e))
-
-  # 2. Build
-  to_build = []
-  if requirements:
-    for req in requirements:
-      local_project = local_project_from_requirement(req)
-      if local_project:
-        to_build.append(local_project)
-  if requirement_files:
-    for requirement_file in requirement_files:
-      to_build.extend(local_projects_from_requirement_file(requirement_file))
-
-  to_install = []
-  if os.path.exists(resolved_dists):
-    for distribution in os.listdir(resolved_dists):
-      path = os.path.join(resolved_dists, distribution)
-      if os.path.isfile(path) and path.endswith('.whl'):
-        to_install.append(path)
-      else:
-        to_build.append(path)
-
-  if not any((to_build, to_install)):
-    # Nothing to build or install.
-    return []
-
-  if to_build:
-    with TRACER.timed('Building distributions:\n  {}'.format('\n  '.join(to_build))):
-      try:
-        build_wheels(distributions=to_build,
-                     target=built_wheels,
-                     cache=cache,
-                     interpreter=interpreter)
-      except PipError as e:
-        raise Untranslateable('Failed to build at least one of {}:\n  {}'
-                              .format(', '.join(to_build), str(e)))
-      to_install.extend(os.path.join(built_wheels, wheel) for wheel in os.listdir(built_wheels))
-
-  # 3. Chroot
-  resolved_distributions = []
-
-  with TRACER.timed('Installing distributions:\n  {}'.format('\n  '.join(to_install))):
-    for wheel_file_path in to_install:
-      wheel_file = os.path.basename(wheel_file_path)
-      chroot = os.path.join(installed_chroots, wheel_file)
-      if os.path.exists(chroot):
-        TRACER.log('Using cached installation of {} at {}'.format(wheel_file, chroot))
-      else:
-        TRACER.log('Installing {} in {}'.format(wheel_file_path, chroot))
-        tmp_chroot = '{}.{}'.format(chroot, uuid4().hex)
-        try:
-          install_wheel(wheel=wheel_file_path,
-                        target=tmp_chroot,
-                        compile=compile,
-                        overwrite=True,
-                        cache=cache,
-                        interpreter=interpreter)
-        except PipError as e:
-          raise Untranslateable('Failed to install {}:\n\t{}'.format(wheel_file_path, e))
-        os.rename(tmp_chroot, chroot)
-
-      environment = Environment(search_path=[chroot])
-      for dist_project_name in environment:
-        resolved_distributions.extend(environment[dist_project_name])
-
-  with TRACER.timed('Determining environment markers of installed distributions:\n  {}'
-                    .format('\n  '.join(map(str, resolved_distributions)))):
-    markers_by_req_key = _calculate_dependency_markers(
-      resolved_distributions,
-      interpreter=interpreter
-    )
-
-  def to_requirement(dist):
-    req = dist.as_requirement()
-    markers = markers_by_req_key.get(req.key)
-    if not markers:
-      return req
-
-    if len(markers) == 1:
-      marker = next(iter(markers))
-      req.marker = marker
-      return req
-
-    # Here we have a resolve with multiple paths to the dependency represented by dist. At least
-    # two of those paths had (different) conditional requirements for dist based on environment
-    # marker predicates. Since the pip resolve succeeded, the implication is that the environment
-    # markers are compatible; i.e.: their intersection selects the target interpreter. Here we
-    # make that intersection explicit.
-    # See: https://www.python.org/dev/peps/pep-0496/#micro-language
-    marker = ' and '.join('({})'.format(marker) for marker in markers)
-    return Requirement.parse('{}; {}'.format(req, marker))
-
-  return [ResolvedDistribution(to_requirement(dist), dist) for dist in resolved_distributions]
+  return list(resolve_request.resolve_distributions())
 
 
 def resolve_multi(requirements=None,
@@ -301,7 +617,8 @@ def resolve_multi(requirements=None,
                   cache=None,
                   build=True,
                   use_wheel=True,
-                  compile=True):
+                  compile=False,
+                  max_parallel_jobs=None):
   """A generator function that produces all distributions needed to meet `requirements`
   for multiple interpreters and/or platforms.
 
@@ -338,38 +655,26 @@ def resolve_multi(requirements=None,
     Defaults to ``True``.
   :keyword bool compile: Whether to pre-compile resolved distribution python sources.
     Defaults to ``False``.
-  :yields: All :class:`ResolvedDistribution` instances meeting ``requirements`` for all
-    specifed interpreters and platforms.
+  :keyword int max_parallel_jobs: The maximum number of parallel jobs to use when resolving,
+    building and installing distributions in a resolve. Defaults to the number of CPUs available.
+  :returns: List of :class:`ResolvedDistribution` instances meeting ``requirements``.
   :raises Unsatisfiable: If ``requirements`` is not transitively satisfiable.
   :raises Untranslateable: If no compatible distributions could be acquired for
     a particular requirement.
   """
 
-  curried_resolve = functools.partial(resolve,
-                                      requirements=requirements,
-                                      requirement_files=requirement_files,
-                                      constraint_files=constraint_files,
-                                      allow_prereleases=allow_prereleases,
-                                      transitive=transitive,
-                                      indexes=indexes,
-                                      find_links=find_links,
-                                      cache=cache,
-                                      build=build,
-                                      use_wheel=use_wheel,
-                                      compile=compile)
-
   parsed_platforms = [parsed_platform(platform) for platform in platforms] if platforms else []
 
-  def iter_kwargs():
+  def iter_targets():
     if not interpreters and not parsed_platforms:
       # No specified targets, so just build for the current interpreter (on the current platform).
-      yield dict(interpreter=None, platform=None)
+      yield DistributionTarget.current()
       return
 
     if interpreters:
       for interpreter in interpreters:
         # Build for the specified local interpreters (on the current platform).
-        yield dict(interpreter=interpreter, platform=None)
+        yield DistributionTarget.for_interpreter(interpreter)
 
     if parsed_platforms:
       for platform in parsed_platforms:
@@ -377,13 +682,20 @@ def resolve_multi(requirements=None,
           # 1. Build for specific platforms.
           # 2. Build for the current platform (None) only if not done already (ie: no intepreters
           #    were specified).
-          yield dict(interpreter=None, platform=platform)
+          yield DistributionTarget.for_platform(platform)
 
-  seen = set()
-  for kwargs in iter_kwargs():
-    for resolved_distribution in curried_resolve(**kwargs):
-      # The resolved wheel name is a suitable multi-platform distinguishing key.
-      key = os.path.basename(resolved_distribution.distribution.location)
-      if key not in seen:
-        seen.add(key)
-        yield resolved_distribution
+  resolve_request = ResolveRequest(targets=list(iter_targets()),
+                                   requirements=requirements,
+                                   requirement_files=requirement_files,
+                                   constraint_files=constraint_files,
+                                   allow_prereleases=allow_prereleases,
+                                   transitive=transitive,
+                                   indexes=indexes,
+                                   find_links=find_links,
+                                   cache=cache,
+                                   build=build,
+                                   use_wheel=use_wheel,
+                                   compile=compile,
+                                   max_parallel_jobs=max_parallel_jobs)
+
+  return list(resolve_request.resolve_distributions())

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -1,18 +1,19 @@
+# coding=utf-8
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import absolute_import
 
-import errno
 import functools
 import json
 import os
 import subprocess
 from collections import OrderedDict, defaultdict, namedtuple
 from textwrap import dedent
-from uuid import uuid4
 
-from pex.common import safe_mkdtemp
+from pex.pex_info import PexInfo
+
+from pex.common import AtomicDirectory, atomic_directory, safe_mkdtemp
 from pex.distribution_target import DistributionTarget
 from pex.jobs import SpawnedJob, execute_parallel, spawn_python_job
 from pex.orderedset import OrderedSet
@@ -126,35 +127,6 @@ def parsed_platform(platform=None):
   return Platform.create(platform) if platform and platform != 'current' else None
 
 
-class AtomicDirectory(namedtuple('AtomicDirectory', ['work_dir', 'target_dir'])):
-  @classmethod
-  def for_target_dir(cls, target_dir):
-    return cls(work_dir='{}.{}'.format(target_dir, uuid4().hex), target_dir=target_dir)
-
-  @property
-  def is_finalized(self):
-    return os.path.exists(self.target_dir)
-
-  def finalize(self):
-    if self.is_finalized:
-      return
-
-    try:
-      # Perform an atomic rename.
-      #
-      # Per the docs: https://docs.python.org/2.7/library/os.html#os.rename
-      #
-      #   The operation may fail on some Unix flavors if src and dst are on different filesystems.
-      #   If successful, the renaming will be an atomic operation (this is a POSIX requirement).
-      #
-      # We have satisfied the single filesystem constraint by arranging the `work_dir` to be a
-      # sibling of the `target_dir`.
-      os.rename(self.work_dir, self.target_dir)
-    except OSError as e:
-      if e.errno != errno.ENOTEMPTY:
-        raise e
-
-
 class ResolveResult(namedtuple('ResolveResult', ['target', 'download_dir'])):
   @staticmethod
   def _is_wheel(path):
@@ -198,7 +170,7 @@ class BuildResult(namedtuple('BuildResult', ['request', 'atomic_dir'])):
       build_request.fingerprint,
       build_request.target.id
     )
-    return cls(request=build_request, atomic_dir=AtomicDirectory.for_target_dir(dist_dir))
+    return cls(request=build_request, atomic_dir=AtomicDirectory(dist_dir))
 
   @property
   def is_built(self):
@@ -232,7 +204,7 @@ class InstallRequest(namedtuple('InstallRequest', ['target', 'wheel_path', 'fing
     return InstallResult.from_request(self, installation_root=installation_root)
 
 
-class InstallResult(namedtuple('InstallResult', ['request', 'atomic_dir'])):
+class InstallResult(namedtuple('InstallResult', ['request', 'installation_root', 'atomic_dir'])):
   @classmethod
   def from_request(cls, install_request, installation_root):
     install_chroot = os.path.join(
@@ -240,7 +212,11 @@ class InstallResult(namedtuple('InstallResult', ['request', 'atomic_dir'])):
       install_request.fingerprint,
       install_request.wheel_file
     )
-    return cls(request=install_request, atomic_dir=AtomicDirectory.for_target_dir(install_chroot))
+    return cls(
+      request=install_request,
+      installation_root=installation_root,
+      atomic_dir=AtomicDirectory(install_chroot)
+    )
 
   @property
   def is_installed(self):
@@ -256,6 +232,63 @@ class InstallResult(namedtuple('InstallResult', ['request', 'atomic_dir'])):
 
   def finalize_install(self, install_requests):
     self.atomic_dir.finalize()
+
+    # The install_chroot is keyed by the hash of the wheel file (zip) we installed. Here we add a
+    # key by the hash of the exploded wheel dir (the install_chroot). This latter key is used by
+    # zipped PEXes at runtime to explode their wheel chroots to the filesystem. By adding the key
+    # here we short-circuit the explode process for PEXes created and run on the same machine.
+    #
+    # From a clean cache after building a simple pex this looks like:
+    # $ rm -rf ~/.pex
+    # $ python -mpex -c pex -o /tmp/pex.pex .
+    # $ tree -L 4 ~/.pex/
+    # /home/jsirois/.pex/
+    # ├── built_wheels
+    # │   └── 1003685de2c3604dc6daab9540a66201c1d1f718
+    # │       └── cp-38-cp38
+    # │           └── pex-2.0.2-py2.py3-none-any.whl
+    # └── installed_wheels
+    #     ├── 2a594cef34d2e9109bad847358d57ac4615f81f4
+    #     │   └── pex-2.0.2-py2.py3-none-any.whl
+    #     │       ├── bin
+    #     │       ├── pex
+    #     │       └── pex-2.0.2.dist-info
+    #     └── ae13cba3a8e50262f4d730699a11a5b79536e3e1
+    #         └── pex-2.0.2-py2.py3-none-any.whl -> /home/jsirois/.pex/installed_wheels/2a594cef34d2e9109bad847358d57ac4615f81f4/pex-2.0.2-py2.py3-none-any.whl  # noqa
+    #
+    # 11 directories, 1 file
+    #
+    # And we see in the created pex, the runtime key that the layout above satisfies:
+    # $ unzip -qc /tmp/pex.pex PEX-INFO | jq .distributions
+    # {
+    #   "pex-2.0.2-py2.py3-none-any.whl": "ae13cba3a8e50262f4d730699a11a5b79536e3e1"
+    # }
+    #
+    # When the pex is run, the runtime key is followed to the build time key, avoiding re-unpacking
+    # the wheel:
+    # $ PEX_VERBOSE=1 /tmp/pex.pex --version
+    # pex: Found site-library: /usr/lib/python3.8/site-packages
+    # pex: Tainted path element: /usr/lib/python3.8/site-packages
+    # pex: Scrubbing from user site: /home/jsirois/.local/lib/python3.8/site-packages
+    # pex: Scrubbing from site-packages: /usr/lib/python3.8/site-packages
+    # pex: Activating PEX virtual environment from /tmp/pex.pex: 9.1ms
+    # pex: Bootstrap complete, performing final sys.path modifications...
+    # pex: PYTHONPATH contains:
+    # pex:     /tmp/pex.pex
+    # pex:   * /usr/lib/python38.zip
+    # pex:     /usr/lib/python3.8
+    # pex:     /usr/lib/python3.8/lib-dynload
+    # pex:     /home/jsirois/.pex/installed_wheels/2a594cef34d2e9109bad847358d57ac4615f81f4/pex-2.0.2-py2.py3-none-any.whl  # noqa
+    # pex:   * /tmp/pex.pex/.bootstrap
+    # pex:   * - paths that do not exist or will be imported via zipimport
+    # pex.pex 2.0.2
+    #
+    wheel_dir_hash = CacheHelper.dir_hash(self.install_chroot)
+    runtime_key_dir = os.path.join(self.installation_root, wheel_dir_hash)
+    with atomic_directory(runtime_key_dir) as work_dir:
+      if work_dir:
+        os.symlink(self.install_chroot, os.path.join(work_dir, self.request.wheel_file))
+
     return self._iter_requirements_requests(install_requests)
 
   def _iter_requirements_requests(self, install_requests):
@@ -442,7 +475,7 @@ class ResolveRequest(object):
     spawn_wheel_build = functools.partial(self._spawn_wheel_build, built_wheels_dir)
     to_build = list(self._iter_local_projects())
 
-    installed_wheels_dir = os.path.join(cache, 'installed_wheels')
+    installed_wheels_dir = os.path.join(cache, PexInfo.INSTALL_CACHE)
     spawn_install = functools.partial(self._spawn_install, installed_wheels_dir)
     to_install = []
 

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -11,12 +11,11 @@ import subprocess
 from collections import OrderedDict, defaultdict, namedtuple
 from textwrap import dedent
 
-from pex.pex_info import PexInfo
-
 from pex.common import AtomicDirectory, atomic_directory, safe_mkdtemp
 from pex.distribution_target import DistributionTarget
 from pex.jobs import SpawnedJob, execute_parallel, spawn_python_job
 from pex.orderedset import OrderedSet
+from pex.pex_info import PexInfo
 from pex.pip import spawn_build_wheels, spawn_download_distributions, spawn_install_wheel
 from pex.platforms import Platform
 from pex.requirements import local_project_from_requirement, local_projects_from_requirement_file

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -20,7 +20,7 @@ from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
-from pex.pip import build_wheels
+from pex.pip import spawn_build_wheels
 from pex.util import DistributionHelper, named_temporary_file
 
 PY_VER = sys.version_info[:2]
@@ -156,11 +156,11 @@ class WheelBuilder(object):
     self._interpreter = interpreter or PythonInterpreter.get()
 
   def bdist(self):
-    build_wheels(
+    spawn_build_wheels(
       distributions=[self._source_dir],
-      target=self._wheel_dir,
+      wheel_dir=self._wheel_dir,
       interpreter=self._interpreter
-    )
+    ).wait()
     dists = os.listdir(self._wheel_dir)
     if len(dists) == 0:
       raise self.BuildFailure('No distributions were produced!')

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -75,9 +75,6 @@ class Variables(object):
   def copy(self):
     return self._environ.copy()
 
-  def set(self, variable, value):
-    self._environ[variable] = str(value)
-
   def _defaulted(self, default):
     return default if self._use_defaults else None
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,7 +17,7 @@ import pytest
 from pex.common import safe_copy, safe_open, safe_sleep, temporary_dir
 from pex.compatibility import WINDOWS, nested, to_bytes
 from pex.pex_info import PexInfo
-from pex.pip import build_wheels, download_distributions
+from pex.pip import spawn_build_wheels, spawn_download_distributions
 from pex.testing import (
     NOT_CPYTHON27,
     NOT_CPYTHON27_OR_OSX,
@@ -1342,9 +1342,15 @@ def test_issues_539_abi3_resolution():
     # sdist. Since we want to test in --no-build, we pre-resolve/build the pycparser wheel here and
     # add the resulting wheelhouse to the --no-build pex command.
     download_dir = os.path.join(td, '.downloads')
-    download_distributions(target=download_dir, requirements=['pycparser'])
+    spawn_download_distributions(
+      download_dir=download_dir,
+      requirements=['pycparser']
+    ).wait()
     wheel_dir = os.path.join(td, '.wheels')
-    build_wheels(target=wheel_dir, distributions=glob.glob(os.path.join(download_dir, '*')))
+    spawn_build_wheels(
+      wheel_dir=wheel_dir,
+      distributions=glob.glob(os.path.join(download_dir, '*'))
+    ).wait()
 
     cryptography_pex = os.path.join(td, 'cryptography.pex')
     res = run_pex_command(['-f', wheel_dir,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -69,7 +69,6 @@ def test_pex_root():
     results.assert_success()
     assert ['pex.pex'] == os.listdir(output_dir), 'Expected built pex file.'
     assert [] == os.listdir(tmp_home), 'Expected empty temp home dir.'
-    assert 'build' in os.listdir(td), 'Expected build directory in tmp pex root.'
 
 
 def test_cache_disable():

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,24 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pex.jobs import _ABSOLUTE_MAX_JOBS, DEFAULT_MAX_JOBS, _sanitize_max_jobs
+
+
+def test_sanitize_max_jobs_none():
+  assert DEFAULT_MAX_JOBS == _sanitize_max_jobs(None)
+
+
+def test_sanitize_max_jobs_less_then_one():
+  assert DEFAULT_MAX_JOBS == _sanitize_max_jobs(0)
+  assert DEFAULT_MAX_JOBS == _sanitize_max_jobs(-1)
+  assert DEFAULT_MAX_JOBS == _sanitize_max_jobs(-5)
+
+
+def test_sanitize_max_jobs_nominal():
+  assert 1 == _sanitize_max_jobs(1)
+
+
+def test_sanitize_max_jobs_too_large():
+  assert _ABSOLUTE_MAX_JOBS == _sanitize_max_jobs(_ABSOLUTE_MAX_JOBS)
+  assert _ABSOLUTE_MAX_JOBS == _sanitize_max_jobs(_ABSOLUTE_MAX_JOBS + 1)
+  assert _ABSOLUTE_MAX_JOBS == _sanitize_max_jobs(_ABSOLUTE_MAX_JOBS + 5)

--- a/tests/test_unified_install_cache.py
+++ b/tests/test_unified_install_cache.py
@@ -10,7 +10,7 @@ from textwrap import dedent
 import pytest
 
 from pex import pip
-from pex.common import safe_rmtree, safe_open, safe_mkdir
+from pex.common import safe_mkdir, safe_open, safe_rmtree, safe_mkdtemp
 from pex.pex_info import PexInfo
 from pex.testing import run_pex_command
 
@@ -20,7 +20,9 @@ def pex_project_dir():
   return subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).decode('utf-8').strip()
 
 
-def test_issues_789_demo(pex_project_dir, tmpdir):
+def test_issues_789_demo(pex_project_dir):
+  tmpdir = safe_mkdtemp()
+
   # 1. Imagine we've pre-resolved the requirements needed in our wheel house.
   requirements = [
     'ansicolors',
@@ -37,7 +39,7 @@ def test_issues_789_demo(pex_project_dir, tmpdir):
   # 2. Also imagine this configuration is passed to a tool (PEX or a wrapper as in this test
   # example) via the CLI or other configuration data sources. For example, Pants has a `PythonSetup`
   # that combines with BUILD target data to get you this sort of configuration info outside pex.
-  resolver_settings=dict(
+  resolver_settings = dict(
     indexes=[],  # Turn off pypi.
     find_links=[wheelhouse],  # Use our wheel house.
     build=False,  # Use only pre-built wheels.

--- a/tests/test_unified_install_cache.py
+++ b/tests/test_unified_install_cache.py
@@ -1,0 +1,206 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import json
+import os
+import subprocess
+from subprocess import CalledProcessError
+from textwrap import dedent
+
+import pytest
+
+from pex import pip
+from pex.common import safe_rmtree, safe_open, safe_mkdir
+from pex.pex_info import PexInfo
+from pex.testing import run_pex_command
+
+
+@pytest.fixture(scope='module')
+def pex_project_dir():
+  return subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).decode('utf-8').strip()
+
+
+def test_issues_789_demo(pex_project_dir, tmpdir):
+  # 1. Imagine we've pre-resolved the requirements needed in our wheel house.
+  requirements = [
+    'ansicolors',
+    'isort',
+    'setuptools'  # N.B.: isort doesn't declare its setuptools dependency.
+  ]
+
+  wheelhouse = os.path.join(tmpdir, 'wheelhouse')
+  pip.spawn_download_distributions(
+    download_dir=wheelhouse,
+    requirements=requirements
+  ).wait()
+
+  # 2. Also imagine this configuration is passed to a tool (PEX or a wrapper as in this test
+  # example) via the CLI or other configuration data sources. For example, Pants has a `PythonSetup`
+  # that combines with BUILD target data to get you this sort of configuration info outside pex.
+  resolver_settings=dict(
+    indexes=[],  # Turn off pypi.
+    find_links=[wheelhouse],  # Use our wheel house.
+    build=False,  # Use only pre-built wheels.
+  )
+
+  # 3. That same configuration was used to build a standard pex:
+  resolver_args = []
+  if len(resolver_settings['find_links']) == 0:
+    resolver_args.append('--no-index')
+  else:
+    for index in resolver_settings['indexes']:
+      resolver_args.extend(['--index', index])
+
+  for repo in resolver_settings['find_links']:
+    resolver_args.extend(['--find-links', repo])
+
+  resolver_args.append('--build' if resolver_settings['build'] else '--no-build')
+
+  project_code_dir = os.path.join(tmpdir, 'project_code_dir')
+  with safe_open(os.path.join(project_code_dir, 'colorized_isort.py'), 'w') as fp:
+    fp.write(dedent("""\
+      import colors
+      import os
+      import subprocess
+      import sys
+
+
+      def run():
+        env = os.environ.copy()
+        env.update(PEX_INTERPRETER='1')
+        isort_process = subprocess.Popen(
+          [sys.argv[0], '-m', 'isort'] + sys.argv[1:],
+          env=env,
+          stdout = subprocess.PIPE,
+          stderr = subprocess.PIPE
+        )
+        stdout, stderr = isort_process.communicate()
+        print(colors.green(stdout.decode('utf-8')))
+        print(colors.red(stderr.decode('utf-8')))
+        sys.exit(isort_process.returncode)
+    """))
+
+  colorized_isort_pex = os.path.join(tmpdir, 'colorized_isort.pex')
+  args = [
+    '--sources-directory', project_code_dir,
+    '--entry-point', 'colorized_isort:run',
+    '--output-file', colorized_isort_pex
+  ]
+  result = run_pex_command(args + resolver_args + requirements)
+  result.assert_success()
+
+  # 4. Now the tool builds a "dehydrated" PEX using the standard pex + resolve settings as the
+  # template.
+  ptex_cache = os.path.join(tmpdir, '.ptex')
+
+  colorized_isort_pex_info = PexInfo.from_pex(colorized_isort_pex)
+  colorized_isort_pex_info.pex_root = ptex_cache
+
+  # Force the standard pex to extract its code. An external tool like Pants would already know the
+  # orignal source code file paths, but we need to discover here.
+  colorized_isort_pex_code_dir = os.path.join(
+    colorized_isort_pex_info.zip_unsafe_cache,
+    colorized_isort_pex_info.code_hash
+  )
+  env = os.environ.copy()
+  env.update(PEX_ROOT=ptex_cache, PEX_INTERPRETER='1', PEX_FORCE_LOCAL='1')
+  subprocess.check_call([colorized_isort_pex, '-c', ''], env=env)
+
+  colorized_isort_ptex_code_dir = os.path.join(tmpdir, 'colorized_isort_ptex_code_dir')
+  safe_mkdir(colorized_isort_ptex_code_dir)
+
+  code = []
+  for root, dirs, files in os.walk(colorized_isort_pex_code_dir):
+    rel_root = os.path.relpath(root, colorized_isort_pex_code_dir)
+    for f in files:
+      # Don't ship compiled python from the code extract above, the target interpreter will not
+      # match ours in general.
+      if f.endswith('.pyc'):
+        continue
+      rel_path = os.path.normpath(os.path.join(rel_root, f))
+      # The root __main__.py is special for any zipapp including pex, let it write its own
+      # __main__.py bootstrap. Similarly. PEX-INFO is special to pex and we want the PEX-INFO for
+      # The ptex pex, not the pex being ptexed.
+      if rel_path in ('__main__.py', PexInfo.PATH):
+        continue
+      os.symlink(os.path.join(root, f), os.path.join(colorized_isort_ptex_code_dir, rel_path))
+      code.append(rel_path)
+
+  ptex_code_dir = os.path.join(tmpdir, 'ptex_code_dir')
+
+  ptex_info = dict(code=code, resolver_settings=resolver_settings)
+  with safe_open(os.path.join(ptex_code_dir, 'PTEX-INFO'), 'w') as fp:
+    json.dump(ptex_info, fp)
+
+  with safe_open(os.path.join(ptex_code_dir, 'IPEX-INFO'), 'w') as fp:
+    fp.write(colorized_isort_pex_info.dump())
+
+  with safe_open(os.path.join(ptex_code_dir, 'ptex.py'), 'w') as fp:
+    fp.write(dedent("""\
+      import json
+      import os
+      import sys
+
+      from pex import resolver
+      from pex.common import open_zip
+      from pex.pex_builder import PEXBuilder
+      from pex.pex_info import PexInfo
+      from pex.util import CacheHelper
+      from pex.variables import ENV
+
+      self = sys.argv[0]
+      ipex_file = '{}.ipex'.format(os.path.splitext(self)[0])
+
+      if not os.path.isfile(ipex_file):
+        print('Hydrating {} to {}'.format(self, ipex_file))
+
+        ptex_pex_info = PexInfo.from_pex(self)
+        code_root = os.path.join(ptex_pex_info.zip_unsafe_cache, ptex_pex_info.code_hash)
+        with open_zip(self) as zf:
+          # Populate the pex with the pinned requirements and distribution names & hashes.
+          ipex_info = PexInfo.from_json(zf.read('IPEX-INFO'))
+          ipex_builder = PEXBuilder(pex_info=ipex_info)
+
+          # Populate the pex with the needed code.
+          ptex_info = json.load(zf.open('PTEX-INFO'))
+          for path in ptex_info['code']:
+            ipex_builder.add_source(os.path.join(code_root, path), path)
+
+        # Perform a fully pinned intransitive resolve to hydrate the install cache (not the
+        # pex!).
+        resolver_settings = ptex_info['resolver_settings']
+        resolved_distributions = resolver.resolve(
+          requirements=[str(req) for req in ipex_info.requirements],
+          cache=ipex_info.pex_root,
+          transitive=False,
+          **resolver_settings
+        )
+
+        ipex_builder.build(ipex_file)
+
+      os.execv(ipex_file, [ipex_file] + sys.argv[1:])
+    """))
+
+  colorized_isort_ptex = os.path.join(tmpdir, 'colorized_isort.ptex')
+
+  result = run_pex_command([
+    '--not-zip-safe',
+    '--always-write-cache',
+    '--pex-root', ptex_cache,
+    pex_project_dir,
+    '--sources-directory', ptex_code_dir,
+    '--sources-directory', colorized_isort_ptex_code_dir,
+    '--entry-point', 'ptex',
+    '--output-file', colorized_isort_ptex
+  ])
+  result.assert_success()
+
+  subprocess.check_call([colorized_isort_ptex, '--version'])
+  with pytest.raises(CalledProcessError):
+    subprocess.check_call([colorized_isort_ptex, '--not-a-flag'])
+
+  safe_rmtree(ptex_cache)
+
+  # The dehydrated pex now fails since it lost its hydration from the cache.
+  with pytest.raises(CalledProcessError):
+    subprocess.check_call([colorized_isort_ptex, '--version'])

--- a/tests/test_unified_install_cache.py
+++ b/tests/test_unified_install_cache.py
@@ -69,9 +69,9 @@ def test_issues_789_demo(pex_project_dir):
 
       def run():
         env = os.environ.copy()
-        env.update(PEX_INTERPRETER='1')
+        env.update(PEX_MODULE='isort')
         isort_process = subprocess.Popen(
-          [sys.argv[0], '-m', 'isort'] + sys.argv[1:],
+          sys.argv,
           env=env,
           stdout = subprocess.PIPE,
           stderr = subprocess.PIPE
@@ -164,7 +164,7 @@ def test_issues_789_demo(pex_project_dir):
           ipex_builder = PEXBuilder(pex_info=ipex_info)
 
           # Populate the pex with the needed code.
-          ptex_info = json.load(zf.open('PTEX-INFO'))
+          ptex_info = json.loads(zf.read('PTEX-INFO').decode('utf-8'))
           for path in ptex_info['code']:
             ipex_builder.add_source(os.path.join(code_root, path), path)
 

--- a/tests/test_unified_install_cache.py
+++ b/tests/test_unified_install_cache.py
@@ -10,7 +10,7 @@ from textwrap import dedent
 import pytest
 
 from pex import pip
-from pex.common import safe_mkdir, safe_open, safe_rmtree, safe_mkdtemp
+from pex.common import safe_mkdir, safe_mkdtemp, safe_open, safe_rmtree
 from pex.pex_info import PexInfo
 from pex.testing import run_pex_command
 

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -108,14 +108,6 @@ def test_pex_vars_hermetic():
     assert_pex_vars_hermetic()
 
 
-def test_pex_vars_set():
-  v = Variables(environ={})
-  assert v._get_int('HELLO') is None
-  v.set('HELLO', '42')
-  assert v._get_int('HELLO') == 42
-  assert {'HELLO': '42'} == v.copy()
-
-
 def test_pex_get_kv():
   v = Variables(environ={})
   assert v._get_kv('HELLO') is None


### PR DESCRIPTION
Previously these caches were seperate. Downloaded wheels and sdists were
cached in `~/.pex/build` and wheels unzipped from zipped pexes at
runtime were cached to `~/.pex/install`.

Now the caches are unified by the resolver such that any wheel installs
performed by it can be seen by zipped PEXes on the same machine when
they go to potentially unzip wheel distributions stored within at PEX
boot time.

N.B.: The cache is not unified in the other direction. If a zipped PEX
is executed on the same machine a PEX build resolve later happens on,
any intersecting wheels will be re-downloaded, built and installed by
the resolve finally unifying the caches from that point forward.

Fixes #820