### PR TITLE
Windows/wip merge main up to tag `v2.1.120`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v4
+          key: ${{ runner.os }}-pyenv-root-v9
       - name: Run Unit Tests
         uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
@@ -135,7 +135,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v4
+          key: ${{ runner.os }}-pyenv-root-v9
       - name: Run Unit Tests
         uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
@@ -197,7 +197,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v4
+          key: ${{ runner.os }}-pyenv-root-v9
       - name: Setup SSH Agent
         uses: webfactory/ssh-agent@v0.5.4
         env:
@@ -254,7 +254,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
-          key: ${{ runner.os }}-pyenv-root-v4
+          key: ${{ runner.os }}-pyenv-root-v9
       - name: Setup SSH Agent
         uses: webfactory/ssh-agent@v0.5.4
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,20 +58,17 @@ jobs:
             python-version: [ 3, 5 ]
             pip-version: 20
           - os: macos-11
-            python-version: [ 3, 10 ]
+            python-version: [ 3, 11 ]
             pip-version: 20
           - os: ubuntu-20.04
-            python-version: [ 3, 10 ]
+            python-version: [ 3, 11 ]
             pip-version: 20
           - os: ubuntu-20.04
-            python-version: [ 3, 10 ]
+            python-version: [ 3, 11 ]
             pip-version: 22_2
           - os: ubuntu-20.04
-            python-version: [ 3, 10 ]
+            python-version: [ 3, 11 ]
             pip-version: 22_3
-          - os: ubuntu-20.04
-            python-version: [ 3, 11, "0-rc.2" ]
-            pip-version: 20
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -163,20 +160,17 @@ jobs:
             python-version: [ 3, 7 ]
             pip-version: 22_3
           - os: macos-11
-            python-version: [ 3, 10 ]
+            python-version: [ 3, 11 ]
             pip-version: 20
           - os: ubuntu-20.04
-            python-version: [ 3, 10 ]
+            python-version: [ 3, 11 ]
             pip-version: 20
           - os: ubuntu-20.04
-            python-version: [ 3, 10 ]
+            python-version: [ 3, 11 ]
             pip-version: 22_2
           - os: ubuntu-20.04
-            python-version: [ 3, 10 ]
+            python-version: [ 3, 11 ]
             pip-version: 22_3
-          - os: ubuntu-20.04
-            python-version: [ 3, 11, "0-rc.2" ]
-            pip-version: 20
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,46 +47,31 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [[2, 7], [3, 5], [3, 6], [3, 7], [3, 8], [3, 9], [3, 10], [3, 11, "0-rc.2"]]
-        os: [ubuntu-20.04, macos-11]
-        pip-version: ["20", "22"]
-        exclude:
+        include:
           - os: macos-11
-            python-version: [2, 7]
-            pip-version: "22"
-          - os: macos-11
-            python-version: [3, 5]
-          - os: macos-11
-            python-version: [3, 6]
-          - os: macos-11
-            python-version: [3, 7]
-          - os: macos-11
-            python-version: [3, 8]
-          - os: macos-11
-            python-version: [3, 9]
-          - os: macos-11
-            python-version: [3, 10]
-            pip-version: "20"
-          - os: macos-11
-            python-version: [3, 11, "0-rc.2"]
+            python-version: [ 2, 7 ]
+            pip-version: 20
           - os: ubuntu-20.04
-            python-version: [3, 5]
-            pip-version: "22"
+            python-version: [ 2, 7 ]
+            pip-version: 20
           - os: ubuntu-20.04
-            python-version: [3, 6]
-            pip-version: "22"
+            python-version: [ 3, 5 ]
+            pip-version: 20
+          - os: macos-11
+            python-version: [ 3, 10 ]
+            pip-version: 20
           - os: ubuntu-20.04
-            python-version: [3, 7]
-            pip-version: "20"
+            python-version: [ 3, 10 ]
+            pip-version: 20
           - os: ubuntu-20.04
-            python-version: [3, 8]
-            pip-version: "20"
+            python-version: [ 3, 10 ]
+            pip-version: 22_2
           - os: ubuntu-20.04
-            python-version: [3, 9]
-            pip-version: "20"
+            python-version: [ 3, 10 ]
+            pip-version: 22_3
           - os: ubuntu-20.04
-            python-version: [3, 11, "0-rc.2"]
-            pip-version: "20"
+            python-version: [ 3, 11, "0-rc.2" ]
+            pip-version: 20
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -121,11 +106,15 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        pypy-version: [[2, 7], [3, 9]]
-        pip-version: ["20", "22"]
-        exclude:
-          - pypy-version: [2, 7]
-            pip-version: "22"
+        include:
+          - pypy-version: [ 2, 7 ]
+            pip-version: 20
+          - pypy-version: [ 3, 9 ]
+            pip-version: 20
+          - pypy-version: [ 3, 9 ]
+            pip-version: 22_2
+          - pypy-version: [ 3, 9 ]
+            pip-version: 22_3
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -160,18 +149,34 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [[2, 7], [3, 10], [3, 11, "0-rc.2"]]
-        os: [ubuntu-20.04, macos-11]
-        pip-version: ["20", "22"]
-        exclude:
+        include:
           - os: macos-11
-            python-version: [3, 11, "0-rc.2"]
-          - os: macos-11
-            python-version: [2, 7]
-            pip-version: "22"
+            python-version: [ 2, 7 ]
+            pip-version: 20
           - os: ubuntu-20.04
-            python-version: [3, 11, "0-rc.2"]
-            pip-version: "22"
+            python-version: [ 2, 7 ]
+            pip-version: 20
+          - os: ubuntu-20.04
+            python-version: [ 3, 7 ]
+            pip-version: 22_2
+          - os: ubuntu-20.04
+            python-version: [ 3, 7 ]
+            pip-version: 22_3
+          - os: macos-11
+            python-version: [ 3, 10 ]
+            pip-version: 20
+          - os: ubuntu-20.04
+            python-version: [ 3, 10 ]
+            pip-version: 20
+          - os: ubuntu-20.04
+            python-version: [ 3, 10 ]
+            pip-version: 22_2
+          - os: ubuntu-20.04
+            python-version: [ 3, 10 ]
+            pip-version: 22_3
+          - os: ubuntu-20.04
+            python-version: [ 3, 11, "0-rc.2" ]
+            pip-version: 20
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose
@@ -216,11 +221,15 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        pypy-version: [[2, 7], [3, 9]]
-        pip-version: ["20", "22"]
-        exclude:
-          - pypy-version: [2, 7]
-            pip-version: "22"
+        include:
+          - pypy-version: [ 2, 7 ]
+            pip-version: 20
+          - pypy-version: [ 3, 9 ]
+            pip-version: 20
+          - pypy-version: [ 3, 9 ]
+            pip-version: 22_2
+          - pypy-version: [ 3, 9 ]
+            pip-version: 22_3
     steps:
       - name: Calculate Pythons to Expose
         id: calculate-pythons-to-expose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,18 +27,18 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Pex
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # We need branches and tags since package leans on `git describe`. Passing 0 gets us
           # complete history.
           fetch-depth: 0
       - name: Setup Python 3.8
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           # We need to keep Python 3.8 for consistent vendoring with tox.
           python-version: "3.8"
       - name: Check Formatting, Types, Vendoring and Packaging
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           tox-env: format-check,typecheck,vendor-check,package -- --additional-format sdist --additional-format wheel
   cpython-unit-tests:
@@ -80,24 +80,24 @@ jobs:
           if [[ "$(uname -s)" == "Linux" ]]; then
             skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
           fi
-          echo "::set-output name=skip::${skip}"
+          echo "skip=${skip}" >> $GITHUB_OUTPUT
       - name: Checkout Pex
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
+        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Cache Pyenv Interpreters
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v4
       - name: Run Unit Tests
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}
   pypy-unit-tests:
@@ -123,24 +123,24 @@ jobs:
           if [[ "$(uname -s)" == "Linux" ]]; then
             skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
           fi
-          echo "::set-output name=skip::${skip}"
+          echo "skip=${skip}" >> $GITHUB_OUTPUT
       - name: Checkout Pex
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
+        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Cache Pyenv Interpreters
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v4
       - name: Run Unit Tests
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           tox-env: pypy${{ join(matrix.pypy-version, '') }}-pip${{ matrix.pip-version }}
   cpython-integration-tests:
@@ -185,22 +185,22 @@ jobs:
           if [[ "$(uname -s)" == "Linux" ]]; then
             skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
           fi
-          echo "::set-output name=skip::${skip}"
+          echo "skip=${skip}" >> $GITHUB_OUTPUT
       - name: Checkout Pex
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # We need branches and tags for some ITs.
           fetch-depth: 0
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "${{ join(matrix.python-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
+        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Cache Pyenv Interpreters
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v4
@@ -212,7 +212,7 @@ jobs:
         with:
           ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
       - name: Run Integration Tests
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           tox-env: py${{ matrix.python-version[0] }}${{ matrix.python-version[1] }}-pip${{ matrix.pip-version }}-integration
   pypy-integration-tests:
@@ -238,18 +238,18 @@ jobs:
           if [[ "$(uname -s)" == "Linux" ]]; then
             skip="${{ env._PEX_TEST_PYENV_VERSIONS }}"
           fi
-          echo "::set-output name=skip::${skip}"
+          echo "skip=${skip}" >> $GITHUB_OUTPUT
       - name: Checkout Pex
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # We need branches and tags for some ITs.
           fetch-depth: 0
       - name: Setup PyPy ${{ join(matrix.pypy-version, '.') }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "pypy-${{ join(matrix.pypy-version, '.') }}"
       - name: Expose Pythons
-        uses: pantsbuild/actions/expose-pythons@4c36480012d4d430c9d865222cdb2b6d91713acd
+        uses: pantsbuild/actions/expose-pythons@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           skip: "${{ steps.calculate-pythons-to-expose.outputs.skip }}"
       - name: Install Packages
@@ -257,7 +257,7 @@ jobs:
           # This is needed for `test_requirement_file_from_url` for building `lxml`.
           sudo apt install --yes libxslt-dev
       - name: Cache Pyenv Interpreters
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env._PEX_TEST_PYENV_ROOT }}
           key: ${{ runner.os }}-pyenv-root-v4
@@ -269,7 +269,7 @@ jobs:
         with:
           ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
       - name: Run Integration Tests
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           tox-env: pypy${{ join(matrix.pypy-version, '') }}-pip${{ matrix.pip-version }}-integration
   final-status:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
             RELEASE_TAG=${GITHUB_REF#refs/tags/}
           fi
           if [[ "${RELEASE_TAG}" =~ ^v[0-9]+.[0-9]+.[0-9]+$ ]]; then
-            echo "::set-output name=release-tag::${RELEASE_TAG}"
-            echo "::set-output name=release-version::${RELEASE_TAG#v}"
+            echo "release-tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
+            echo "release-version=${RELEASE_TAG#v}" >> $GITHUB_OUTPUT
           else
             echo "::error::Release tag '${RELEASE_TAG}' must match 'v\d+.\d+.\d+'."
             exit 1
@@ -46,15 +46,15 @@ jobs:
     environment: Release
     steps:
       - name: Checkout Pex ${{ needs.determine-tag.outputs.release-tag }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ needs.determine-tag.outputs.release-tag }}
       - name: Setup Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: Publish Pex ${{ needs.determine-tag.outputs.release-tag }}
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         env:
           FLIT_USERNAME: ${{ secrets.PYPI_USERNAME }}
           FLIT_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
@@ -67,17 +67,17 @@ jobs:
     environment: Release
     steps:
       - name: Checkout Pex ${{ needs.determine-tag.outputs.release-tag }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ needs.determine-tag.outputs.release-tag }}
           # This ensures we get all branches and tags which is needed for `tox -e package`.
           fetch-depth: 0
       - name: Setup Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: Package Pex ${{ needs.determine-tag.outputs.release-tag }} PEX
-        uses: pantsbuild/actions/run-tox@95209b287c817c78a765962d40ac6cea790fc511
+        uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:
           tox-env: package
       - name: Create ${{ needs.determine-tag.outputs.release-tag }} Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ needs.determine-tag.outputs.release-tag }}
-      - name: Setup Python 3.10
+      - name: Setup Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Publish Pex ${{ needs.determine-tag.outputs.release-tag }}
         uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         env:
@@ -72,10 +72,10 @@ jobs:
           ref: ${{ needs.determine-tag.outputs.release-tag }}
           # This ensures we get all branches and tags which is needed for `tox -e package`.
           fetch-depth: 0
-      - name: Setup Python 3.10
+      - name: Setup Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Package Pex ${{ needs.determine-tag.outputs.release-tag }} PEX
         uses: pantsbuild/actions/run-tox@e63d2d0e3c339bdffbe5e51e7c39550e3bc527bb
         with:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,29 @@
 Release Notes
 =============
 
+2.1.120
+-------
+
+This release completes the ``--complete-platform`` fix started in
+Pex 2.1.116 by #1991. That fix did not work in all cases but now does.
+
+PEXes run in interpreter mode now support command history when the
+underlying interpreter being used to run the PEX does; use the
+``PEX_INTERPRETER_HISTORY`` bool env var to turn this on.
+
+Additionally, PEXes built with the combination
+``--layout loose --venv --no-venv-site-packages-copies`` are fixed to
+be robust to moves of the source loose PEX directory.
+
+* Fix loose --venv PEXes to be robust to moves. (#2033)
+  `PR #2033 <https://github.com/pantsbuild/pex/pull/2033>`_
+
+* Fix interpreter resolution when using --complete-platform with --resolve-local-platforms (#2031)
+  `PR #2031 <https://github.com/pantsbuild/pex/pull/2031>`_
+
+* Support REPL command history. (#2018)
+  `PR #2018 <https://github.com/pantsbuild/pex/pull/2018>`_
+
 2.1.119
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+2.1.112
+-------
+
+This release brings support for the latest Pip release and includes
+some internal changes to help debug intermittent issues some users are
+seeing that implicate what may be file locking related bugs.
+
+* Add support for ``--pip-version 22.3``. (#1953)
+  `PR #1953 <https://github.com/pantsbuild/pex/pull/1953>`_
+
 2.1.111
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 Release Notes
 =============
 
+2.1.110
+-------
+
+This release fixes Pex runtime ``sys.path`` scrubbing for cases where
+Pex is not the main entry point. An important example of this is in
+Lambdex where the AWS Lambda Python runtime packages (``boto3`` and
+``botocore``) are leaked into the PEX runtime ``sys.path``.
+
+* Fix ``sys.path`` scrubbing. (#1946)
+  `PR #1946 <https://github.com/pantsbuild/pex/pull/1946>`_
+
 2.1.109
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+2.1.113
+-------
+
+This is a hotfix release that fixes errors installing wheels when there
+is high parallelism in execution of Pex processes. These issues were a
+regression introduced by #1961 included in the 2.1.112 release.
+
+* Restore AtomicDirectory non-locked good behavior. (#1974)
+  `PR #1974 <https://github.com/pantsbuild/pex/pull/1974>`_
+
 2.1.112
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,26 @@
 Release Notes
 =============
 
+2.1.111
+-------
+
+This release fixes resolving requirements from a lock using arbitrary
+equality (``===``).
+
+In addition, you can now "inject" runtime environment variables and
+arguments into PEX files such that, when run, the PEX runtime ensures
+those environment variables and command line arguments are passed to
+the PEXed application. See `PEX Recipes
+<https://pex.readthedocs.io/en/latest/recipes.html
+#uvicorn-and-other-customizable-application-servers>`_ for more
+information.
+
+* Fix lock resolution to handle arbitrary equality. (#1951)
+  `PR #1951 <https://github.com/pantsbuild/pex/pull/1951>`_
+
+* Support injecting args and env vars in a PEX. (#1948)
+  `PR #1948 <https://github.com/pantsbuild/pex/pull/1948>`_
+
 2.1.110
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 Release Notes
 =============
 
+2.1.114
+-------
+
+This release brings two fixes for ``--venv`` mode PEXes.
+
+* Only insert "" to head of sys.path if a venv PEX runs in interpreter mode (#1984)
+  `PR #1984 <https://github.com/pantsbuild/pex/pull/1984>`_
+
+* Map pex python path interpreter to realpath when creating venv dir hash. (#1972)
+  `PR #1972 <https://github.com/pantsbuild/pex/pull/1972>`_
+
 2.1.113
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,24 @@
 Release Notes
 =============
 
+2.1.118
+-------
+
+This is a very tardy hotfix release for a regression introduced in Pex
+2.1.91 by #1785 that replaced sys.argv[0] with its fully resolved path.
+This prevented introspecting the actual file path used to launch the PEX
+which broke BusyBox-alike use cases.
+
+There is also a new ``--non-hermetic-scripts`` option accepted by the
+``venv`` tool to allow running console scripts with ``PYTHONPATH``
+adjustments to the ``sys.path``.
+
+* Remove un-needed realpathing of ``sys.argv[0]``. (#2007)
+  `PR #2007 <https://github.com/pantsbuild/pex/pull/2007>`_
+
+* Add ``--non-hermetic-scripts`` option to ``venv`` tool. (#2010)
+  `PR #2010 <https://github.com/pantsbuild/pex/pull/2010>`_
+
 2.1.117
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,20 @@
 Release Notes
 =============
 
+2.1.119
+-------
+
+This release brings two new features. The venv pex tool now just warns when
+using ``--compile`` and there is a ``*.pyc`` compile error instead of failing
+to create the venv. Also, a new ``PEX_DISABLE_VARIABLES`` env var knob is added
+to turn off reading all ``PEX_*`` env vars from the environment.
+
+* Ignore compile error for PEX_TOOLS=1 (#2002)
+  `PR #2002 <https://github.com/pantsbuild/pex/pull/2002>`_
+
+* Add PEX_DISABLE_VARIABLES to lock down a PEX run. (#2014)
+  `PR #2014 <https://github.com/pantsbuild/pex/pull/2014>`_
+
 2.1.118
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,21 @@
 Release Notes
 =============
 
+2.1.117
+-------
+
+This release fixes a bug introduced in Pex 2.1.109 where the released
+Pex PEX could not be executed by PyPy interpreters. More generally, any
+PEX created with interpreter constraints that did not specify the Python
+implementation, e.g.: ``==3.8.*``, were interpreted as being CPython
+specific, i.e.: ``CPython==3.8.*``. This is now fixed, but if the
+intention of a constraint like ``==3.8.*`` was in fact to restrict to
+CPython only, interpreter constraints need to say so now and use
+``CPython==3.8.*`` explicitly.
+
+* Fix interpreter constraint parsing. (#1998)
+  `PR #1998 <https://github.com/pantsbuild/pex/pull/1998>`_
+
 2.1.116
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+2.1.116
+-------
+
+This release fixes a bug in ``--resolve-local-platforms`` when
+``--complete-platform`` was used.
+
+* Check for --complete-platforms match when --resolve-local-platforms (#1991)
+  `PR #1991 <https://github.com/pantsbuild/pex/pull/1991>`_
+
 2.1.115
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,19 @@
 Release Notes
 =============
 
+2.1.115
+-------
+
+This release brings some attention to the ``pex3 lock export``
+subcommand to make it more useful when inter-operating with
+``pip-tools``.
+
+* Sort requirements based on normalized project name when exporting (#1992)
+  `PR #1992 <https://github.com/pantsbuild/pex/pull/1992>`_
+
+* Use raw version when exporting (#1990)
+  `PR #1990 <https://github.com/pantsbuild/pex/pull/1990>`_
+
 2.1.114
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -144,7 +144,7 @@ is available at https://pex.readthedocs.io.
 Development
 ===========
 
-Pex uses `tox <https://testrun.org/tox/en/latest/>`_ for test and development automation. To run
+Pex uses `tox <https://tox.wiki/en/latest/>`_ for test and development automation. To run
 the test suite, just invoke tox:
 
 .. code-block:: bash
@@ -157,7 +157,7 @@ If you don't have tox, you can generate a pex of tox:
 
     $ pex tox -c tox -o ~/bin/tox
 
-Tox provides many useful commands and options, explained at https://tox.readthedocs.io/en/latest/.
+Tox provides many useful commands and options, explained at https://tox.wiki/en/latest/ .
 Below, we provide some of the most commonly used commands used when working on Pex, but the
 docs are worth acquainting yourself with to better understand how Tox works and how to do more
 advanced commands.

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Overview
 pex is a library for generating .pex (Python EXecutable) files which are
 executable Python environments in the spirit of `virtualenvs <http://virtualenv.org>`_.
 pex is an expansion upon the ideas outlined in
-`PEP 441 <http://legacy.python.org/dev/peps/pep-0441/>`_
+`PEP 441 <https://peps.python.org/pep-0441/>`_
 and makes the deployment of Python applications as simple as ``cp``.  pex files may even
 include multiple platform-specific Python distributions, meaning that a single pex file
 can be portable across Linux and OS X.

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -3,6 +3,40 @@
 PEX Recipes and Notes
 =====================
 
+Uvicorn and other customizable application servers
+--------------------------------------------------
+
+Often you want to run a third-party application server and have it use your code. You can always do
+this by writing a shim bit of python code that starts the application server configured to use your
+code. It may be simpler though to use ``--inject-env`` and ``--inject-args`` to seal this
+configuration into a PEX file without needing to write a shim.
+
+For example, to package up a uvicorn-powered server of your app coroutine in ``example.py`` that ran
+on port 8888 by default you could:
+
+.. code-block:: bash
+
+    $ pex "uvicorn[standard]" -c uvicorn --inject-args 'example:app --port 8888' -oexample-app.pex
+    $ ./example-app.pex
+    INFO:     Started server process [2014]
+    INFO:     Waiting for application startup.
+    INFO:     ASGI 'lifespan' protocol appears unsupported.
+    INFO:     Application startup complete.
+    INFO:     Uvicorn running on http://127.0.0.1:8888 (Press CTRL+C to quit)
+    ^CINFO:     Shutting down
+    INFO:     Finished server process [2014]
+
+You could then over-ride the port with:
+
+.. code-block:: bash
+
+    $ ./example-app.pex --port 0
+    INFO:     Started server process [2248]
+    INFO:     Waiting for application startup.
+    INFO:     ASGI 'lifespan' protocol appears unsupported.
+    INFO:     Application startup complete.
+    INFO:     Uvicorn running on http://127.0.0.1:45751 (Press CTRL+C to quit)
+
 Long running PEX applications and daemons
 -----------------------------------------
 

--- a/docs/whatispex.rst
+++ b/docs/whatispex.rst
@@ -11,7 +11,7 @@ PEX files are self-contained executable Python virtual environments.  More
 specifically, they are carefully constructed zip files with a
 ``#!/usr/bin/env python`` and special ``__main__.py`` that allows you to interact
 with the PEX runtime.  For more information about zip applications,
-see `PEP 441 <https://www.python.org/dev/peps/pep-0441/>`_.
+see `PEP 441 <https://peps.python.org/pep-0441/>`_.
 
 To get started building your first pex files, go straight to :ref:`buildingpex`. 
 
@@ -43,5 +43,5 @@ file.  Adding ``#!/usr/bin/env python`` to the top of a .zip file containing
 a ``__main__.py`` and marking it executable will turn it into an
 executable Python program.  pex takes advantage of this feature in order to
 build executable .pex files.  This is described more thoroughly in
-`PEP 441 <https://www.python.org/dev/peps/pep-0441/>`_.
+`PEP 441 <https://peps.python.org/pep-0441/>`_.
 

--- a/pex/atomic_directory.py
+++ b/pex/atomic_directory.py
@@ -8,6 +8,7 @@ import fcntl
 import os
 import threading
 from contextlib import contextmanager
+from uuid import uuid4
 
 from pex import pex_warnings
 from pex.common import safe_mkdir, safe_rmtree
@@ -19,10 +20,50 @@ if TYPE_CHECKING:
 
 
 class AtomicDirectory(object):
-    def __init__(self, target_dir):
-        # type: (str) -> None
+    """A directory whose contents are populated atomically.
+
+    By default, an atomic directory allows racing processes to populate a directory atomically.
+    Each gets its own unique work directory to populate non-atomically, but the final target
+    directory is swapped to atomically from one of the racing work directories.
+
+    In order to lock the atomic directory so that only 1 process works to populate it, use the
+    `atomic_directory` context manager.
+
+    If the target directory will have immutable contents, either approach will do. If not, the
+    exclusively locked `atomic_directory` context manager should be used.
+
+    The common case for a non-obvious mutable directory in Python is any directory `.py` files are
+    populated to. Those files will later be bytecode compiled to adjacent `.pyc` files on the fly
+    by the Python interpreter and can go missing underneath a process looking at that directory if
+    AtomicDirectory is used directly. For the target directory `sys_path_entry` that failure mode
+    looks like:
+
+    Process A -> Starts work to create `sys_path_entry`.
+    Process B -> Starts work to create `sys_path_entry`.
+    Process A -> Atomically creates `sys_path_entry`.
+    Process C -> Sees `sys_path_entry` from Process A and starts running Python code in that dir.
+    Process D -> Sees `sys_path_entry` from Process A and starts running Python code in that dir.
+    Process D -> Succeeds importing `foo`.
+    Process C -> Starts to import `sys_path_entry/foo.py` and Python sees the corresponding .pyc
+                 file already exists (Process D created it).
+    Process B -> Atomically creates `sys_path_entry`, replacing the result from Process A and
+                 disappearing any `.pyc` files.
+    Process C -> Goes to import from the `.pyc` file it found and errors since it is gone.
+
+    The background facts in this case are that CPython reasonably does a check then act surrounding
+    .pyc files and uses no lock. It assumes Python source trees will not be disturbed during its
+    run. Without an exclusively locked `atomic_directory` Pex can allow the check-then-act window to
+    be observed by racing processes.
+    """
+
+    def __init__(
+        self,
+        target_dir,  # type: str
+        locked=False,  # type: bool
+    ):
+        # type: (...) -> None
         self._target_dir = target_dir
-        self._work_dir = "{}.workdir".format(target_dir)
+        self._work_dir = "{}.{}.work".format(target_dir, "lck" if locked else uuid4().hex)
 
     @property
     def work_dir(self):
@@ -124,7 +165,7 @@ def atomic_directory(
     # We use double-checked locking with the check being target_dir existence and the lock being an
     # exclusive blocking file lock.
 
-    atomic_dir = AtomicDirectory(target_dir=target_dir)
+    atomic_dir = AtomicDirectory(target_dir=target_dir, locked=True)
     if atomic_dir.is_finalized():
         # Our work is already done for us so exit early.
         yield atomic_dir

--- a/pex/atomic_directory.py
+++ b/pex/atomic_directory.py
@@ -1,0 +1,187 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import errno
+import fcntl
+import os
+import threading
+from contextlib import contextmanager
+
+from pex import pex_warnings
+from pex.common import safe_mkdir, safe_rmtree
+from pex.enum import Enum
+from pex.typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from typing import Callable, Iterator, Optional
+
+
+class AtomicDirectory(object):
+    def __init__(self, target_dir):
+        # type: (str) -> None
+        self._target_dir = target_dir
+        self._work_dir = "{}.workdir".format(target_dir)
+
+    @property
+    def work_dir(self):
+        # type: () -> str
+        return self._work_dir
+
+    @property
+    def target_dir(self):
+        # type: () -> str
+        return self._target_dir
+
+    def is_finalized(self):
+        # type: () -> bool
+        return os.path.exists(self._target_dir)
+
+    def finalize(self, source=None):
+        # type: (Optional[str]) -> None
+        """Rename `work_dir` to `target_dir` using `os.rename()`.
+
+        :param source: An optional source offset into the `work_dir`` to use for the atomic update
+                       of `target_dir`. By default, the whole `work_dir` is used.
+
+        If a race is lost and `target_dir` already exists, the `target_dir` dir is left unchanged and
+        the `work_dir` directory will simply be removed.
+        """
+        if self.is_finalized():
+            return
+
+        source = os.path.join(self._work_dir, source) if source else self._work_dir
+        try:
+            # Perform an atomic rename.
+            #
+            # Per the docs: https://docs.python.org/2.7/library/os.html#os.rename
+            #
+            #   The operation may fail on some Unix flavors if src and dst are on different
+            #   filesystems. If successful, the renaming will be an atomic operation (this is a
+            #   POSIX requirement).
+            #
+            # We have satisfied the single filesystem constraint by arranging the `work_dir` to be a
+            # sibling of the `target_dir`.
+            os.rename(source, self._target_dir)
+        except OSError as e:
+            if e.errno not in (errno.EEXIST, errno.ENOTEMPTY):
+                raise e
+        finally:
+            self.cleanup()
+
+    def cleanup(self):
+        # type: () -> None
+        safe_rmtree(self._work_dir)
+
+
+class FileLockStyle(Enum["FileLockStyle.Value"]):
+    class Value(Enum.Value):
+        pass
+
+    BSD = Value("bsd")
+    POSIX = Value("posix")
+
+
+@contextmanager
+def atomic_directory(
+    target_dir,  # type: str
+    lock_style=FileLockStyle.POSIX,  # type: FileLockStyle.Value
+    source=None,  # type: Optional[str]
+):
+    # type: (...) -> Iterator[AtomicDirectory]
+    """A context manager that yields an exclusively locked AtomicDirectory.
+
+    :param target_dir: The target directory to atomically update.
+    :param lock_style: By default, a POSIX fcntl lock will be used to ensure exclusivity.
+    :param source: An optional source offset into the work directory to use for the atomic update
+                   of the target directory. By default, the whole work directory is used.
+
+    If the `target_dir` already exists the enclosed block will be yielded an AtomicDirectory that
+    `is_finalized` to signal there is no work to do.
+
+    If the enclosed block fails the `target_dir` will not be created if it does not already exist.
+
+    The new work directory will be cleaned up regardless of whether the enclosed block succeeds.
+    """
+
+    # We use double-checked locking with the check being target_dir existence and the lock being an
+    # exclusive blocking file lock.
+
+    atomic_dir = AtomicDirectory(target_dir=target_dir)
+    if atomic_dir.is_finalized():
+        # Our work is already done for us so exit early.
+        yield atomic_dir
+        return
+
+    head, tail = os.path.split(atomic_dir.target_dir)
+    if head:
+        safe_mkdir(head)
+    lockfile = os.path.join(head, ".{}.atomic_directory.lck".format(tail or "here"))
+
+    # N.B.: We don't actually write anything to the lock file but the fcntl file locking
+    # operations only work on files opened for at least write.
+    lock_fd = os.open(lockfile, os.O_CREAT | os.O_WRONLY)
+
+    lock_api = cast(
+        "Callable[[int, int], None]",
+        fcntl.flock if lock_style is FileLockStyle.BSD else fcntl.lockf,
+    )
+
+    def unlock():
+        # type: () -> None
+        try:
+            lock_api(lock_fd, fcntl.LOCK_UN)
+        finally:
+            os.close(lock_fd)
+
+    # N.B.: Since lockf and flock operate on an open file descriptor and these are
+    # guaranteed to be closed by the operating system when the owning process exits,
+    # this lock is immune to staleness.
+    lock_api(lock_fd, fcntl.LOCK_EX)  # A blocking write lock.
+    if atomic_dir.is_finalized():
+        # We lost the double-checked locking race and our work was done for us by the race
+        # winner so exit early.
+        try:
+            yield atomic_dir
+        finally:
+            unlock()
+        return
+
+    # If there is an error making the work_dir that means that either file-locking guarantees have
+    # failed somehow and another process has the lock and has made the work_dir already or else a
+    # process holding the lock ended abnormally.
+    try:
+        os.mkdir(atomic_dir.work_dir)
+    except OSError as e:
+        ident = "[pid:{pid}, tid:{tid}, cwd:{cwd}]".format(
+            pid=os.getpid(), tid=threading.current_thread().ident, cwd=os.getcwd()
+        )
+        pex_warnings.warn(
+            "{ident}: After obtaining an exclusive lock on {lockfile}, failed to establish a work "
+            "directory at {workdir} due to: {err}".format(
+                ident=ident,
+                lockfile=lockfile,
+                workdir=atomic_dir.work_dir,
+                err=e,
+            ),
+        )
+        if e.errno != errno.EEXIST:
+            raise
+        pex_warnings.warn(
+            "{ident}: Continuing to forcibly re-create the work directory at {workdir}.".format(
+                ident=ident,
+                workdir=atomic_dir.work_dir,
+            )
+        )
+        safe_mkdir(atomic_dir.work_dir, clean=True)
+
+    try:
+        yield atomic_dir
+    except Exception:
+        atomic_dir.cleanup()
+        raise
+    else:
+        atomic_dir.finalize(source=source)
+    finally:
+        unlock()

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -876,7 +876,11 @@ def do_main(
             compress=options.compress,
         )
         if options.seed != Seed.NONE:
-            seed_info = seed_cache(options, pex, verbose=options.seed == Seed.VERBOSE)
+            seed_info = seed_cache(
+                options,
+                PEX(pex_file, interpreter=interpreter),
+                verbose=options.seed == Seed.VERBOSE,
+            )
             print(seed_info)
     else:
         if not _compatible_with_current_platform(interpreter, targets.platforms):

--- a/pex/bootstrap.py
+++ b/pex/bootstrap.py
@@ -12,6 +12,7 @@ class Bootstrap(object):
 
     @classmethod
     def locate(cls):
+        # type: () -> Bootstrap
         """Locates the active PEX bootstrap.
 
         :rtype: :class:`Bootstrap`
@@ -30,8 +31,14 @@ class Bootstrap(object):
         return cls._INSTANCE
 
     def __init__(self, sys_path_entry):
+        # type: (str) -> None
         self._sys_path_entry = sys_path_entry
         self._realpath = os.path.realpath(self._sys_path_entry)
+
+    @property
+    def path(self):
+        # type: () -> str
+        return self._sys_path_entry
 
     def demote(self):
         """Demote the bootstrap code to the end of the `sys.path` so it is found last.

--- a/pex/cli/commands/lock.py
+++ b/pex/cli/commands/lock.py
@@ -545,7 +545,7 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
                     "{project_name}=={version} \\\n"
                     "  {hashes}\n".format(
                         project_name=pin.project_name,
-                        version=pin.version,
+                        version=pin.version.raw,
                         hashes=" \\\n  ".join(
                             "--hash={algorithm}:{hash}".format(
                                 algorithm=fingerprint.algorithm, hash=fingerprint.hash

--- a/pex/common.py
+++ b/pex/common.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, print_function
 import atexit
 import contextlib
 import errno
-import fcntl
 import itertools
 import os
 import re
@@ -18,12 +17,10 @@ import threading
 import time
 import zipfile
 from collections import defaultdict, namedtuple
-from contextlib import contextmanager
 from datetime import datetime
 from uuid import uuid4
 
-from pex.enum import Enum
-from pex.typing import TYPE_CHECKING, cast
+from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import (
@@ -37,7 +34,6 @@ if TYPE_CHECKING:
         Set,
         Sized,
         Tuple,
-        Union,
     )
 
 # We use the start of MS-DOS time, which is what zipfiles use (see section 4.4.6 of
@@ -331,152 +327,6 @@ def safe_sleep(seconds):
             remaining_time = seconds - (current_time - start_time)
             time.sleep(remaining_time)
             current_time = time.time()
-
-
-class AtomicDirectory(object):
-    def __init__(self, target_dir):
-        # type: (str) -> None
-        self._target_dir = target_dir
-        self._work_dir = "{}.{}".format(target_dir, uuid4().hex)
-
-    @property
-    def work_dir(self):
-        # type: () -> str
-        return self._work_dir
-
-    @property
-    def target_dir(self):
-        # type: () -> str
-        return self._target_dir
-
-    def is_finalized(self):
-        # type: () -> bool
-        return os.path.exists(self._target_dir)
-
-    def finalize(self, source=None):
-        # type: (Optional[str]) -> None
-        """Rename `work_dir` to `target_dir` using `os.rename()`.
-
-        :param source: An optional source offset into the `work_dir`` to use for the atomic update
-                       of `target_dir`. By default the whole `work_dir` is used.
-
-        If a race is lost and `target_dir` already exists, the `target_dir` dir is left unchanged and
-        the `work_dir` directory will simply be removed.
-        """
-        if self.is_finalized():
-            return
-
-        source = os.path.join(self._work_dir, source) if source else self._work_dir
-        try:
-            # Perform an atomic rename.
-            #
-            # Per the docs: https://docs.python.org/2.7/library/os.html#os.rename
-            #
-            #   The operation may fail on some Unix flavors if src and dst are on different filesystems.
-            #   If successful, the renaming will be an atomic operation (this is a POSIX requirement).
-            #
-            # We have satisfied the single filesystem constraint by arranging the `work_dir` to be a
-            # sibling of the `target_dir`.
-            os.rename(source, self._target_dir)
-        except OSError as e:
-            if e.errno not in (errno.EEXIST, errno.ENOTEMPTY):
-                raise e
-        finally:
-            self.cleanup()
-
-    def cleanup(self):
-        # type: () -> None
-        safe_rmtree(self._work_dir)
-
-
-class FileLockStyle(Enum["FileLockStyle.Value"]):
-    class Value(Enum.Value):
-        pass
-
-    BSD = Value("bsd")
-    POSIX = Value("posix")
-
-
-@contextmanager
-def atomic_directory(
-    target_dir,  # type: str
-    exclusive,  # type: Union[bool, FileLockStyle.Value]
-    source=None,  # type: Optional[str]
-):
-    # type: (...) -> Iterator[AtomicDirectory]
-    """A context manager that yields a potentially exclusively locked AtomicDirectory.
-
-    :param target_dir: The target directory to atomically update.
-    :param exclusive: If `True`, its guaranteed that only one process will be yielded a non `None`
-                      workdir; otherwise two or more processes might be yielded unique non-`None`
-                      workdirs with the last process to finish "winning". By default, a POSIX fcntl
-                      lock will be used to ensure exclusivity. To change this, pass an explicit
-                      `LockStyle` instead of `True`.
-    :param source: An optional source offset into the work directory to use for the atomic update
-                   of the target directory. By default the whole work directory is used.
-
-    If the `target_dir` already exists the enclosed block will be yielded an AtomicDirectory that
-    `is_finalized` to signal there is no work to do.
-
-    If the enclosed block fails the `target_dir` will be undisturbed.
-
-    The new work directory will be cleaned up regardless of whether or not the enclosed block
-    succeeds.
-
-    If the contents of the resulting directory will be subsequently mutated it's probably correct to
-    pass `exclusive=True` to ensure mutations that race the creation process are not lost.
-    """
-    atomic_dir = AtomicDirectory(target_dir=target_dir)
-    if atomic_dir.is_finalized():
-        # Our work is already done for us so exit early.
-        yield atomic_dir
-        return
-
-    lock_fd = None  # type: Optional[int]
-    lock_api = cast(
-        "Callable[[int, int], None]",
-        fcntl.flock if exclusive is FileLockStyle.BSD else fcntl.lockf,
-    )
-
-    def unlock():
-        # type: () -> None
-        if lock_fd is None:
-            return
-        try:
-            lock_api(lock_fd, fcntl.LOCK_UN)
-        finally:
-            os.close(lock_fd)
-
-    if exclusive:
-        head, tail = os.path.split(atomic_dir.target_dir)
-        if head:
-            safe_mkdir(head)
-        # N.B.: We don't actually write anything to the lock file but the fcntl file locking
-        # operations only work on files opened for at least write.
-        lock_fd = os.open(
-            os.path.join(head, ".{}.atomic_directory.lck".format(tail or "here")),
-            os.O_CREAT | os.O_WRONLY,
-        )
-        # N.B.: Since lockf and flock operate on an open file descriptor and these are
-        # guaranteed to be closed by the operating system when the owning process exits,
-        # this lock is immune to staleness.
-        lock_api(lock_fd, fcntl.LOCK_EX)  # A blocking write lock.
-        if atomic_dir.is_finalized():
-            # We lost the double-checked locking race and our work was done for us by the race
-            # winner so exit early.
-            try:
-                yield atomic_dir
-            finally:
-                unlock()
-            return
-
-    try:
-        os.makedirs(atomic_dir.work_dir)
-        yield atomic_dir
-        atomic_dir.finalize(source=source)
-    finally:
-        unlock()
-        atomic_dir.cleanup()
 
 
 def chmod_plus_x(path):

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import sysconfig
 from collections import OrderedDict
+from contextlib import contextmanager
 from textwrap import dedent
 
 from pex import third_party
@@ -24,6 +25,7 @@ from pex.orderedset import OrderedSet
 from pex.pep_425 import CompatibilityTags
 from pex.pep_508 import MarkerEnvironment
 from pex.platforms import Platform
+from pex.pth import iter_pth_paths
 from pex.pyenv import Pyenv
 from pex.third_party.packaging import __version__ as packaging_version
 from pex.third_party.packaging import tags
@@ -98,6 +100,49 @@ class PythonIdentity(object):
             return None
         return str(value)
 
+    @staticmethod
+    def _iter_site_packages():
+        # type: () -> Iterator[str]
+
+        try:
+            from site import getsitepackages
+
+            for path in getsitepackages():
+                yield path
+        except ImportError as e:
+            # The site.py provided by old virtualenv (which we use to create some venvs) does not
+            # include a getsitepackages function.
+            TRACER.log("The site module does not define getsitepackages: {err}".format(err=e))
+
+        try:
+            from distutils.sysconfig import get_python_lib
+
+            yield get_python_lib(plat_specific=False)
+            yield get_python_lib(plat_specific=True)
+        except ImportError as e:
+            # The distutils.sysconfig module is deprecated in Python 3.10 but still around.
+            # Eventually it will go away with replacements in sysconfig that we'll add at that time
+            # as another site packages source.
+            TRACER.log(
+                "The distutils.sysconfig module does not define get_python_lib: {err}".format(err=e)
+            )
+
+    @staticmethod
+    def _iter_extras_paths(site_packages):
+        # type: (Iterable[str]) -> Iterator[str]
+
+        # Handle .pth injected paths as extras.
+        for dir_path in site_packages:
+            if not os.path.isdir(dir_path):
+                continue
+            for file in os.listdir(dir_path):
+                if not file.endswith(".pth"):
+                    continue
+                pth_path = os.path.join(dir_path, file)
+                TRACER.log("Found .pth file: {pth_file}".format(pth_file=pth_path), V=3)
+                for extras_path in iter_pth_paths(pth_path):
+                    yield extras_path
+
     @classmethod
     def get(cls, binary=None):
         # type: (Optional[str]) -> PythonIdentity
@@ -127,7 +172,18 @@ class PythonIdentity(object):
         pythonpath = frozenset(
             os.environ.get("PYTHONPATH", "").split(os.pathsep) + list(third_party.exposed())
         )
-        sys_path = [item for item in sys.path if item and item not in pythonpath]
+        sys_path = OrderedSet(item for item in sys.path if item and item not in pythonpath)
+
+        site_packages = OrderedSet(
+            path
+            for path in cls._iter_site_packages()
+            # On Windows getsitepackages() includes sys.prefix as a historical vestige. In PEP-250
+            # Windows got a proper dedicated directory for this which is what is used in the Pythons
+            # we support. See: https://peps.python.org/pep-0250/
+            if path != sys.prefix
+        )
+
+        extras_paths = OrderedSet(cls._iter_extras_paths(site_packages=site_packages))
 
         return cls(
             binary=binary or sys.executable,
@@ -140,6 +196,8 @@ class PythonIdentity(object):
                 or cast(str, getattr(sys, "base_prefix", sys.prefix))
             ),
             sys_path=sys_path,
+            site_packages=site_packages,
+            extras_paths=extras_paths,
             packaging_version=packaging_version,
             python_tag=preferred_tag.interpreter,
             abi_tag=preferred_tag.abi,
@@ -154,7 +212,7 @@ class PythonIdentity(object):
     def decode(cls, encoded):
         TRACER.log("creating PythonIdentity from encoded: %s" % encoded, V=9)
         values = json.loads(encoded)
-        if len(values) != 12:
+        if len(values) != 14:
             raise cls.InvalidError("Invalid interpreter identity: %s" % encoded)
 
         supported_tags = values.pop("supported_tags")
@@ -190,6 +248,8 @@ class PythonIdentity(object):
         prefix,  # type: str
         base_prefix,  # type: str
         sys_path,  # type: Iterable[str]
+        site_packages,  # type: Iterable[str]
+        extras_paths,  # type: Iterable[str]
         packaging_version,  # type: str
         python_tag,  # type: str
         abi_tag,  # type: str
@@ -208,6 +268,8 @@ class PythonIdentity(object):
         self._prefix = prefix
         self._base_prefix = base_prefix
         self._sys_path = tuple(sys_path)
+        self._site_packages = tuple(site_packages)
+        self._extras_paths = tuple(extras_paths)
         self._packaging_version = packaging_version
         self._python_tag = python_tag
         self._abi_tag = abi_tag
@@ -223,6 +285,8 @@ class PythonIdentity(object):
             prefix=self._prefix,
             base_prefix=self._base_prefix,
             sys_path=self._sys_path,
+            site_packages=self._site_packages,
+            extras_paths=self._extras_paths,
             packaging_version=self._packaging_version,
             python_tag=self._python_tag,
             abi_tag=self._abi_tag,
@@ -254,6 +318,16 @@ class PythonIdentity(object):
     def sys_path(self):
         # type: () -> Tuple[str, ...]
         return self._sys_path
+
+    @property
+    def site_packages(self):
+        # type: () -> Tuple[str, ...]
+        return self._site_packages
+
+    @property
+    def extras_paths(self):
+        # type: () -> Tuple[str, ...]
+        return self._extras_paths
 
     @property
     def python_tag(self):
@@ -405,6 +479,19 @@ class PythonInterpreter(object):
     )
 
     _PYTHON_INTERPRETER_BY_NORMALIZED_PATH = {}  # type: Dict
+
+    @classmethod
+    @contextmanager
+    def _cleared_memory_cache(cls):
+        # type: () -> Iterator[None]
+        # Intended for test use.
+
+        _cache = cls._PYTHON_INTERPRETER_BY_NORMALIZED_PATH.copy()
+        cls._PYTHON_INTERPRETER_BY_NORMALIZED_PATH = {}
+        try:
+            yield
+        finally:
+            cls._PYTHON_INTERPRETER_BY_NORMALIZED_PATH = _cache
 
     @staticmethod
     def _get_pyvenv_cfg(path):
@@ -610,9 +697,6 @@ class PythonInterpreter(object):
         cmd = [binary]
 
         # Don't add the user site directory to `sys.path`.
-        #
-        # Additionally, it would be nice to pass `-S` to disable adding site-packages but unfortunately
-        # some python distributions include portions of the standard library there.
         cmd.append("-s")
 
         env = cls._sanitized_environment(env=env)
@@ -1007,6 +1091,18 @@ class PythonInterpreter(object):
         with no adornments.
         """
         return self._identity.sys_path
+
+    @property
+    def site_packages(self):
+        # type: () -> Tuple[str, ...]
+        """Return the interpreter's site packages directories."""
+        return self.identity.site_packages
+
+    @property
+    def extras_paths(self):
+        # type: () -> Tuple[str, ...]
+        """Return any extra paths adjoined to the `sys.path` via the .pth mechanism."""
+        return self.identity.extras_paths
 
     class BaseInterpreterResolutionError(Exception):
         """Indicates the base interpreter for a virtual environment could not be resolved."""

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -828,12 +828,13 @@ class PythonInterpreter(object):
                         import os
                         import sys
 
-                        from pex.common import atomic_directory, safe_open
+                        from pex.atomic_directory import atomic_directory
+                        from pex.common import safe_open
                         from pex.interpreter import PythonIdentity
 
 
                         encoded_identity = PythonIdentity.get(binary={binary!r}).encode()
-                        with atomic_directory({cache_dir!r}, exclusive=False) as cache_dir:
+                        with atomic_directory({cache_dir!r}) as cache_dir:
                             if not cache_dir.is_finalized():
                                 with safe_open(
                                     os.path.join(cache_dir.work_dir, {info_file!r}), 'w'

--- a/pex/layout.py
+++ b/pex/layout.py
@@ -8,7 +8,8 @@ import zipfile
 from abc import abstractmethod
 from contextlib import contextmanager
 
-from pex.common import atomic_directory, is_script, open_zip, safe_copy, safe_mkdir
+from pex.atomic_directory import atomic_directory
+from pex.common import is_script, open_zip, safe_copy, safe_mkdir
 from pex.enum import Enum
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
@@ -104,7 +105,7 @@ def _install(
     with TRACER.timed("Laying out {}".format(layout)):
         pex = layout.path
         install_to = unzip_dir(pex_root=pex_root, pex_hash=pex_hash)
-        with atomic_directory(install_to, exclusive=True) as chroot:
+        with atomic_directory(install_to) as chroot:
             if not chroot.is_finalized():
                 with TRACER.timed("Installing {} to {}".format(pex, install_to)):
                     from pex.pex_info import PexInfo
@@ -124,7 +125,7 @@ def _install(
                         )
 
                     with atomic_directory(
-                        bootstrap_cache, source=layout.bootstrap_strip_prefix(), exclusive=True
+                        bootstrap_cache, source=layout.bootstrap_strip_prefix()
                     ) as bootstrap_zip_chroot:
                         if not bootstrap_zip_chroot.is_finalized():
                             layout.extract_bootstrap(bootstrap_zip_chroot.work_dir)
@@ -139,7 +140,6 @@ def _install(
                         with atomic_directory(
                             spread_dest,
                             source=layout.dist_strip_prefix(location),
-                            exclusive=True,
                         ) as spread_chroot:
                             if not spread_chroot.is_finalized():
                                 layout.extract_dist(spread_chroot.work_dir, dist_relpath)
@@ -154,7 +154,7 @@ def _install(
                         )
 
                     code_dest = os.path.join(pex_info.zip_unsafe_cache, code_hash)
-                    with atomic_directory(code_dest, exclusive=True) as code_chroot:
+                    with atomic_directory(code_dest) as code_chroot:
                         if not code_chroot.is_finalized():
                             layout.extract_code(code_chroot.work_dir)
                     for path in os.listdir(code_dest):

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -18,6 +18,7 @@ from pex.executor import Executor
 from pex.finders import get_entry_point_from_console_script, get_script_from_distributions
 from pex.inherit_path import InheritPath
 from pex.interpreter import PythonInterpreter
+from pex.layout import Layout
 from pex.orderedset import OrderedSet
 from pex.pex_info import PexInfo
 from pex.targets import LocalInterpreter
@@ -162,8 +163,16 @@ class PEX(object):  # noqa: T000
         self._vars = env
         self._envs = None  # type: Optional[Iterable[PEXEnvironment]]
         self._activated_dists = None  # type: Optional[Iterable[Distribution]]
+        self._layout = None  # type: Optional[Layout.Value]
         if verify_entry_point:
             self._do_entry_point_verification()
+
+    @property
+    def layout(self):
+        # type: () -> Layout.Value
+        if self._layout is None:
+            self._layout = Layout.identify(self._pex)
+        return self._layout
 
     def pex_info(self, include_env_overrides=True):
         # type: (bool) -> PexInfo

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -671,6 +671,21 @@ class PEX(object):  # noqa: T000
                 sys.argv = args
                 return self.execute_content(arg, content)
         else:
+            if self._vars.PEX_INTERPRETER_HISTORY:
+                import atexit
+                import readline
+
+                histfile = os.path.expanduser(self._vars.PEX_INTERPRETER_HISTORY_FILE)
+                try:
+                    readline.read_history_file(histfile)
+                    readline.set_history_length(1000)
+                except OSError as e:
+                    sys.stderr.write(
+                        "Failed to read history file at {} due to: {}".format(histfile, e)
+                    )
+
+                atexit.register(readline.write_history_file, histfile)
+
             self.demote_bootstrap()
 
             import code

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -628,6 +628,7 @@ class PEX(object):  # noqa: T000
         # type: () -> Any
 
         # A Python interpreter always inserts the CWD at the head of the sys.path.
+        # See https://docs.python.org/3/library/sys.html#sys.path
         sys.path.insert(0, "")
 
         args = sys.argv[1:]

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -8,7 +8,8 @@ import os
 import sys
 
 from pex import pex_warnings
-from pex.common import atomic_directory, die, pluralize
+from pex.atomic_directory import atomic_directory
+from pex.common import die, pluralize
 from pex.environment import ResolveError
 from pex.inherit_path import InheritPath
 from pex.interpreter import PythonInterpreter
@@ -482,7 +483,7 @@ def ensure_venv(
             "The PEX_VENV environment variable was set, but this PEX was not built with venv "
             "support (Re-build the PEX file with `pex --venv ...`)"
         )
-    with atomic_directory(venv_dir, exclusive=True) as venv:
+    with atomic_directory(venv_dir) as venv:
         if not venv.is_finalized():
             from pex.venv.pex import populate_venv
             from pex.venv.virtualenv import Virtualenv
@@ -505,7 +506,7 @@ def ensure_venv(
             for chars in range(8, len(venv_hash) + 1):
                 entropy = venv_hash[:chars]
                 short_venv_dir = os.path.join(pex_info.pex_root, "venvs", "s", entropy)
-                with atomic_directory(short_venv_dir, exclusive=True) as short_venv:
+                with atomic_directory(short_venv_dir) as short_venv:
                     if short_venv.is_finalized():
                         collisions.append(short_venv_dir)
                         if entropy == venv_hash:

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -127,7 +127,7 @@ if __entry_point__ is None:
   sys.exit(2)
 
 __installed_from__ = os.environ.pop(__INSTALLED_FROM__, None)
-sys.argv[0] = os.path.realpath(__installed_from__ or sys.argv[0])
+sys.argv[0] = __installed_from__ or sys.argv[0]
 
 sys.path[0] = os.path.abspath(sys.path[0])
 sys.path.insert(0, os.path.abspath(os.path.join(__entry_point__, {bootstrap_dir!r})))

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -9,9 +9,9 @@ import os
 import shutil
 
 from pex import pex_warnings
+from pex.atomic_directory import atomic_directory
 from pex.common import (
     Chroot,
-    atomic_directory,
     chmod_plus_x,
     filter_pyc_files,
     is_pyc_temporary_file,
@@ -724,9 +724,7 @@ class PEXBuilder(object):
         cached_bootstrap_zip_dir = zip_cache_dir(
             os.path.join(pex_info.pex_root, "bootstrap_zips", bootstrap_hash)
         )
-        with atomic_directory(
-            cached_bootstrap_zip_dir, exclusive=False
-        ) as atomic_bootstrap_zip_dir:
+        with atomic_directory(cached_bootstrap_zip_dir) as atomic_bootstrap_zip_dir:
             if not atomic_bootstrap_zip_dir.is_finalized():
                 self._chroot.zip(
                     os.path.join(atomic_bootstrap_zip_dir.work_dir, pex_info.bootstrap),
@@ -750,9 +748,7 @@ class PEXBuilder(object):
                 cached_installed_wheel_zip_dir = zip_cache_dir(
                     os.path.join(pex_info.pex_root, "installed_wheel_zips", fingerprint)
                 )
-                with atomic_directory(
-                    cached_installed_wheel_zip_dir, exclusive=False
-                ) as atomic_zip_dir:
+                with atomic_directory(cached_installed_wheel_zip_dir) as atomic_zip_dir:
                     if not atomic_zip_dir.is_finalized():
                         self._chroot.zip(
                             os.path.join(atomic_zip_dir.work_dir, location),

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -166,6 +166,26 @@ class PexInfo(object):
         self._pex_info["build_properties"].update(value)
 
     @property
+    def inject_env(self):
+        # type: () -> Dict[str, str]
+        return dict(self._pex_info.get("inject_env", {}))
+
+    @inject_env.setter
+    def inject_env(self, value):
+        # type: (Mapping[str, str]) -> None
+        self._pex_info["inject_env"] = dict(value)
+
+    @property
+    def inject_args(self):
+        # type: () -> Tuple[str, ...]
+        return tuple(self._pex_info.get("inject_args", ()))
+
+    @inject_args.setter
+    def inject_args(self, value):
+        # type: (Iterable[str]) -> None
+        self._pex_info["inject_args"] = tuple(value)
+
+    @property
     def venv(self):
         # type: () -> bool
         """Whether or not PEX should be converted to a venv before it's executed.

--- a/pex/pip/installation.py
+++ b/pex/pip/installation.py
@@ -7,7 +7,7 @@ import os
 from textwrap import dedent
 
 from pex import pex_warnings, third_party
-from pex.common import atomic_directory
+from pex.atomic_directory import atomic_directory
 from pex.interpreter import PythonInterpreter
 from pex.orderedset import OrderedSet
 from pex.pex import PEX
@@ -38,7 +38,7 @@ def _pip_venv(
     path = os.path.join(ENV.PEX_ROOT, "pip-{version}.pex".format(version=version))
     pip_interpreter = interpreter or PythonInterpreter.get()
     pip_pex_path = os.path.join(path, isolated().pex_hash)
-    with atomic_directory(pip_pex_path, exclusive=True) as chroot:
+    with atomic_directory(pip_pex_path) as chroot:
         if not chroot.is_finalized():
             from pex.pex_builder import PEXBuilder
 

--- a/pex/pip/version.py
+++ b/pex/pip/version.py
@@ -83,4 +83,15 @@ class PipVersion(Enum["PipVersionValue"]):
         wheel_version="0.37.1",
         requires_python=">=3.7",
     )
+
+    v22_3 = PipVersionValue(
+        version="22.3",
+        # TODO(John Sirois): Expose setuptools and wheel version flags - these don't affect
+        #  Pex; so we should allow folks to experiment with upgrade easily:
+        #  https://github.com/pantsbuild/pex/issues/1895
+        setuptools_version="65.5.0",
+        wheel_version="0.37.1",
+        requires_python=">=3.7",
+    )
+
     VENDORED = v20_3_4_patched

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -9,7 +9,8 @@ import re
 from textwrap import dedent
 
 from pex import compatibility
-from pex.common import atomic_directory, safe_open, safe_rmtree
+from pex.atomic_directory import atomic_directory
+from pex.common import safe_open, safe_rmtree
 from pex.pep_425 import CompatibilityTags
 from pex.third_party.packaging import tags
 from pex.tracer import TRACER
@@ -265,7 +266,7 @@ class Platform(object):
         if manylinux:
             components.append(manylinux)
         disk_cache_key = os.path.join(ENV.PEX_ROOT, "platforms", self.SEP.join(components))
-        with atomic_directory(target_dir=disk_cache_key, exclusive=False) as cache_dir:
+        with atomic_directory(target_dir=disk_cache_key) as cache_dir:
             if not cache_dir.is_finalized():
                 # Missed both caches - spawn calculation.
                 plat_info = attr.asdict(self)

--- a/pex/pth.py
+++ b/pex/pth.py
@@ -1,0 +1,74 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os
+import sys
+
+from pex.compatibility import PY2, exec_function
+from pex.tracer import TRACER
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Iterator
+
+
+def iter_pth_paths(filename):
+    # type: (str) -> Iterator[str]
+    """Given a .pth file, extract and yield all inner paths without honoring imports.
+
+    This shadows Python's site.py behavior, which is invoked at interpreter startup.
+    """
+    try:
+        f = open(filename, "rU" if PY2 else "r")  # noqa
+    except IOError:
+        return
+
+    seen = set()
+    with f:
+        for i, line in enumerate(f, start=1):
+            line = line.rstrip()
+            if not line or line.startswith("#"):
+                continue
+            elif line.startswith(("import ", "import\t")):
+                # One important side effect of executing import lines can be alteration of the
+                # sys.path directly or indirectly as a programmatic way to add sys.path entries
+                # in contrast to the standard .pth mechanism of including fixed paths as
+                # individual lines in the file. Here we capture all such programmatic attempts
+                # to expand the sys.path and report the additions.
+                original_sys_path = sys.path[:]
+                try:
+                    # N.B.: Setting sys.path to empty is ok since all the .pth files we find and
+                    # execute have already been found and executed by our ambient sys.executable
+                    # when it started up before running this PEX file. As such, all symbols imported
+                    # by the .pth files then will still be available now as cached in sys.modules.
+                    sys.path = []
+                    exec_function(line, globals_map={})
+                    for path in sys.path:
+                        norm_path = os.path.normcase(path)
+                        if norm_path not in seen:
+                            yield path
+                            seen.add(norm_path)
+                except Exception as e:
+                    # NB: import lines are routinely abused with extra code appended using `;` so
+                    # the class of exceptions that might be raised in broader than ImportError. As
+                    # such we catch broadly here.
+                    TRACER.log(
+                        "Error executing line {linenumber} of {pth_file} with content:\n"
+                        "{content}\n"
+                        "Error was:\n"
+                        "{error}".format(linenumber=i, pth_file=filename, content=line, error=e),
+                        V=9,
+                    )
+
+                    # Defer error handling to the higher level site.py logic invoked at startup.
+                    return
+                finally:
+                    sys.path = original_sys_path
+            else:
+                extras_dir = os.path.abspath(os.path.join(os.path.dirname(filename), line))
+                norm_extras_dir = os.path.normcase(extras_dir)
+                if norm_extras_dir not in seen and os.path.exists(extras_dir):
+                    yield extras_dir
+                    seen.add(norm_extras_dir)

--- a/pex/resolve/downloads.py
+++ b/pex/resolve/downloads.py
@@ -4,7 +4,8 @@ import os.path
 import shutil
 
 from pex import hashing
-from pex.common import atomic_directory, safe_mkdir, safe_mkdtemp
+from pex.atomic_directory import atomic_directory
+from pex.common import safe_mkdir, safe_mkdtemp
 from pex.compatibility import unquote, urlparse
 from pex.fetcher import URLFetcher
 from pex.hashing import Sha256
@@ -71,7 +72,7 @@ class ArtifactDownloader(object):
         hashing.file_hash(path, digest)
         fingerprint = digest.hexdigest()
         target_dir = os.path.join(get_downloads_dir(), fingerprint)
-        with atomic_directory(target_dir, exclusive=True) as atomic_dir:
+        with atomic_directory(target_dir) as atomic_dir:
             if not atomic_dir.is_finalized():
                 shutil.move(path, os.path.join(atomic_dir.work_dir, os.path.basename(path)))
         return Fingerprint(algorithm=fingerprint.algorithm, hash=fingerprint)

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -10,8 +10,9 @@ from collections import OrderedDict
 from multiprocessing.pool import ThreadPool
 
 from pex import resolver
+from pex.atomic_directory import FileLockStyle
 from pex.auth import PasswordDatabase, PasswordEntry
-from pex.common import FileLockStyle, pluralize
+from pex.common import pluralize
 from pex.compatibility import cpu_count
 from pex.network_configuration import NetworkConfiguration
 from pex.orderedset import OrderedSet

--- a/pex/resolve/locked_resolve.py
+++ b/pex/resolve/locked_resolve.py
@@ -605,8 +605,8 @@ class LockedResolve(object):
                     # https://peps.python.org/pep-0440/#handling-of-pre-releases during the lock
                     # resolve; so we trust that resolve's conclusion about prereleases and are
                     # permissive here.
-                    if not resolve_request.requirement.specifier.contains(
-                        str(locked_requirement.pin.version), prereleases=True
+                    if not resolve_request.requirement.contains(
+                        locked_requirement.pin.version, prereleases=True
                     ):
                         version_mismatches.append(
                             "{specifier} ({via})".format(

--- a/pex/resolve/lockfile/download_manager.py
+++ b/pex/resolve/lockfile/download_manager.py
@@ -8,7 +8,8 @@ import json
 import os
 
 from pex import hashing
-from pex.common import FileLockStyle, atomic_directory, safe_rmtree
+from pex.atomic_directory import FileLockStyle, atomic_directory
+from pex.common import safe_rmtree
 from pex.pep_503 import ProjectName
 from pex.resolve.downloads import get_downloads_dir
 from pex.resolve.locked_resolve import Artifact
@@ -127,7 +128,7 @@ class DownloadManager(Generic["_A"]):
         download_dir = os.path.join(
             get_downloads_dir(pex_root=self._pex_root), artifact.fingerprint.hash
         )
-        with atomic_directory(download_dir, exclusive=self._file_lock_style) as atomic_dir:
+        with atomic_directory(download_dir, lock_style=self._file_lock_style) as atomic_dir:
             if atomic_dir.is_finalized():
                 TRACER.log("Using cached artifact at {} for {}".format(download_dir, artifact))
             else:

--- a/pex/resolve/lockfile/json_codec.py
+++ b/pex/resolve/lockfile/json_codec.py
@@ -368,7 +368,10 @@ def as_json_data(
                 "locked_requirements": [
                     {
                         "project_name": str(req.pin.project_name),
-                        "version": str(req.pin.version),
+                        # N.B.: We store the raw version so that `===` can work as intended against
+                        # the un-normalized form of versions that are non-legacy and thus
+                        # normalizable.
+                        "version": req.pin.version.raw,
                         "requires_dists": [
                             path_mappings.maybe_canonicalize(str(dependency))
                             for dependency in req.requires_dists

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -13,8 +13,9 @@ from abc import abstractmethod
 from collections import OrderedDict, defaultdict
 
 from pex import targets
+from pex.atomic_directory import AtomicDirectory, atomic_directory
 from pex.auth import PasswordEntry
-from pex.common import AtomicDirectory, atomic_directory, safe_mkdir, safe_mkdtemp
+from pex.common import safe_mkdir, safe_mkdtemp
 from pex.dist_metadata import Distribution, Requirement
 from pex.fingerprinted_distribution import FingerprintedDistribution
 from pex.jobs import Raise, SpawnedJob, execute_parallel
@@ -449,7 +450,7 @@ class InstallResult(object):
         #
         wheel_dir_hash = fingerprint_path(self.install_chroot)
         runtime_key_dir = os.path.join(self._installation_root, wheel_dir_hash)
-        with atomic_directory(runtime_key_dir, exclusive=False) as atomic_dir:
+        with atomic_directory(runtime_key_dir) as atomic_dir:
             if not atomic_dir.is_finalized():
                 # Note: Create a relative path symlink between the two directories so that the
                 # PEX_ROOT can be used within a chroot environment where the prefix of the path may

--- a/pex/sh_boot.py
+++ b/pex/sh_boot.py
@@ -53,11 +53,16 @@ def _calculate_applicable_binary_names(
     if interpreter_constraints:
         ic_majors_minors.update(
             PythonBinaryName(
-                name=calculate_binary_name(interpreter_constraint.requirement.name), version=version
+                name=calculate_binary_name(platform_python_implementation=name), version=version
             )
             for interpreter_constraint in interpreter_constraints
             for version in iter_compatible_versions(
                 requires_python=[str(interpreter_constraint.requires_python)]
+            )
+            for name in (
+                (interpreter_constraint.name,)
+                if interpreter_constraint.name
+                else ("CPython", "PyPy")
             )
         )
     # If we get targets from ICs, we only want explicitly specified local interpreter targets;

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -484,7 +484,7 @@ def ensure_python_distribution(version):
 
     pip = os.path.join(interpreter_location, "bin", "pip")
 
-    with atomic_directory(target_dir=os.path.join(pyenv_root)) as target_dir:
+    with atomic_directory(target_dir=pyenv_root) as target_dir:
         if not target_dir.is_finalized():
             bootstrap_python_installer(target_dir.work_dir)
 
@@ -495,9 +495,9 @@ def ensure_python_distribution(version):
                     "git",
                     "--git-dir={}".format(os.path.join(pyenv_root, ".git")),
                     "--work-tree={}".format(pyenv_root),
-                    "pull",
-                    "--ff-only",
-                    "https://github.com/pyenv/pyenv.git",
+                    "reset",
+                    "--hard",
+                    "v2.3.8",
                 ]
             )
             env = pyenv_env.copy()

--- a/pex/testing.py
+++ b/pex/testing.py
@@ -10,27 +10,18 @@ import platform
 import random
 import subprocess
 import sys
-from collections import OrderedDict
 from contextlib import contextmanager
 from textwrap import dedent
 
 import pytest
 
-from pex.common import (
-    atomic_directory,
-    open_zip,
-    safe_mkdir,
-    safe_mkdtemp,
-    safe_rmtree,
-    safe_sleep,
-    temporary_dir,
-)
+from pex.atomic_directory import atomic_directory
+from pex.common import open_zip, safe_mkdir, safe_mkdtemp, safe_rmtree, safe_sleep, temporary_dir
 from pex.compatibility import to_unicode
 from pex.dist_metadata import Distribution
 from pex.enum import Enum
 from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
-from pex.orderedset import OrderedSet
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
@@ -493,13 +484,11 @@ def ensure_python_distribution(version):
 
     pip = os.path.join(interpreter_location, "bin", "pip")
 
-    with atomic_directory(target_dir=os.path.join(pyenv_root), exclusive=True) as target_dir:
+    with atomic_directory(target_dir=os.path.join(pyenv_root)) as target_dir:
         if not target_dir.is_finalized():
             bootstrap_python_installer(target_dir.work_dir)
 
-    with atomic_directory(
-        target_dir=interpreter_location, exclusive=True
-    ) as interpreter_target_dir:
+    with atomic_directory(target_dir=interpreter_location) as interpreter_target_dir:
         if not interpreter_target_dir.is_finalized():
             subprocess.check_call(
                 [

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -447,7 +447,7 @@ def isolated():
     global _ISOLATED
     if _ISOLATED is None:
         from pex import layout, vendor
-        from pex.common import atomic_directory
+        from pex.atomic_directory import atomic_directory
         from pex.util import CacheHelper
         from pex.variables import ENV
 
@@ -491,7 +491,7 @@ def isolated():
 
         isolated_dir = os.path.join(ENV.PEX_ROOT, "isolated", pex_hash)
         with _tracer().timed("Isolating pex"):
-            with atomic_directory(isolated_dir, exclusive=True) as chroot:
+            with atomic_directory(isolated_dir) as chroot:
                 if not chroot.is_finalized():
                     with _tracer().timed("Extracting pex to {}".format(isolated_dir)):
                         if pex_zip_paths:

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -164,6 +164,16 @@ class Venv(PEXCommand):
                 )
             ),
         )
+        parser.add_argument(
+            "--non-hermetic-scripts",
+            dest="hermetic_scripts",
+            action="store_false",
+            default=True,
+            help=(
+                "Don't rewrite console script shebangs in the venv to pass `-sE` to the interpreter; "
+                "for example, to enable running venv scripts with a custom `PYTHONPATH`."
+            ),
+        )
         cls.register_global_arguments(parser, include_verbosity=False)
 
     def run(self, pex):
@@ -196,6 +206,7 @@ class Venv(PEXCommand):
             collisions_ok=self.options.collisions_ok,
             symlink=False,
             scope=self.options.scope,
+            hermetic_scripts=self.options.hermetic_scripts,
         )
         if self.options.pip:
             try:

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -8,8 +8,10 @@ import logging
 import os
 from argparse import ArgumentParser
 
+from pex import pex_warnings
 from pex.common import safe_delete, safe_rmtree
 from pex.enum import Enum
+from pex.executor import Executor
 from pex.pex import PEX
 from pex.result import Error, Ok, Result
 from pex.tools.command import PEXCommand
@@ -217,7 +219,11 @@ class Venv(PEXCommand):
                     "installed:\n{}".format(e)
                 )
         if self.options.compile:
-            pex.interpreter.execute(["-m", "compileall", venv_dir])
+            try:
+                pex.interpreter.execute(["-m", "compileall", venv_dir])
+            except Executor.NonZeroExit as non_zero_exit:
+                pex_warnings.warn("ignoring compile error {}".format(repr(non_zero_exit)))
+
         if self.options.remove is not None:
             if os.path.isdir(pex.path()):
                 safe_rmtree(pex.path())

--- a/pex/util.py
+++ b/pex/util.py
@@ -8,7 +8,6 @@ import hashlib
 import importlib
 import os
 import shutil
-import sys
 import tempfile
 from hashlib import sha1
 from site import makepath  # type: ignore[attr-defined]
@@ -20,7 +19,6 @@ from pex.compatibility import (  # type: ignore[attr-defined]  # `exec_function`
     exec_function,
 )
 from pex.orderedset import OrderedSet
-from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -140,61 +138,3 @@ def named_temporary_file(**kwargs):
             yield fp
     finally:
         os.remove(fp.name)
-
-
-def iter_pth_paths(filename):
-    # type: (str) -> Iterator[str]
-    """Given a .pth file, extract and yield all inner paths without honoring imports.
-
-    This shadows Python's site.py behavior, which is invoked at interpreter startup.
-    """
-    try:
-        f = open(filename, "rU" if PY2 else "r")  # noqa
-    except IOError:
-        return
-
-    dirname = os.path.dirname(filename)
-    known_paths = set()
-
-    with f:
-        for i, line in enumerate(f, start=1):
-            line = line.rstrip()
-            if not line or line.startswith("#"):
-                continue
-            elif line.startswith(("import ", "import\t")):
-                # One important side effect of executing import lines can be alteration of the
-                # sys.path directly or indirectly as a programmatic way to add sys.path entries
-                # in contrast to the standard .pth mechanism of including fixed paths as
-                # individual lines in the file. Here we capture all such programmatic attempts
-                # to expand the sys.path and report the additions.
-                original_sys_path = sys.path[:]
-                try:
-                    # N.B.: Setting sys.path to empty is ok since all the .pth files we find and
-                    # execute have already been found and executed by our ambient sys.executable
-                    # when it started up before running this PEX file. As such, all symbols imported
-                    # by the .pth files then will still be available now as cached in sys.modules.
-                    sys.path = []
-                    exec_function(line, globals_map={})
-                    for path in sys.path:
-                        yield path
-                except Exception as e:
-                    # NB: import lines are routinely abused with extra code appended using `;` so
-                    # the class of exceptions that might be raised in broader than ImportError. As
-                    # such we catch broadly here.
-                    TRACER.log(
-                        "Error executing line {linenumber} of {pth_file} with content:\n"
-                        "{content}\n"
-                        "Error was:\n"
-                        "{error}".format(linenumber=i, pth_file=filename, content=line, error=e),
-                        V=9,
-                    )
-
-                    # Defer error handling to the higher level site.py logic invoked at startup.
-                    return
-                finally:
-                    sys.path = original_sys_path
-            else:
-                extras_dir, extras_dir_case_insensitive = makepath(dirname, line)
-                if extras_dir_case_insensitive not in known_paths and os.path.exists(extras_dir):
-                    yield extras_dir
-                    known_paths.add(extras_dir_case_insensitive)

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -189,8 +189,8 @@ class Variables(object):
         """
         ret_vars = {}  # type: Dict[str, str]
         rc_locations = [
-            "/etc/pexrc",
-            "~/.pexrc",
+            os.path.join(os.sep, "etc", "pexrc"),
+            os.path.join("~", ".pexrc"),
             os.path.join(os.path.dirname(sys.argv[0]), ".pexrc"),
         ]
         if rc:
@@ -520,6 +520,32 @@ class Variables(object):
         """
         return self._get_bool("PEX_INTERPRETER")
 
+    @defaulted_property(default=False)
+    def PEX_INTERPRETER_HISTORY(self):
+        # type: () -> bool
+        """Boolean.
+
+        IF PEX_INTERPRETER is true, use a command history file for REPL user convenience.
+        The location of the history file is determined by PEX_INTERPRETER_HISTORY_FILE.
+
+        Note: Only supported on CPython interpreters.
+
+        Default: false.
+        """
+        return self._get_bool("PEX_INTERPRETER_HISTORY")
+
+    @defaulted_property(default=os.path.join("~", ".python_history"))
+    def PEX_INTERPRETER_HISTORY_FILE(self):
+        # type: () -> str
+        """File.
+
+        IF PEX_INTERPRETER_HISTORY is true, use this history file.
+        The default is the standard CPython interpreter history location.
+
+        Default: ~/.python_history.
+        """
+        return self._get_string("PEX_INTERPRETER_HISTORY_FILE")
+
     @property
     def PEX_MODULE(self):
         # type: () -> Optional[str]
@@ -607,7 +633,7 @@ class Variables(object):
         )
         return self._maybe_get_path_tuple("PEX_EXTRA_SYS_PATH") or ()
 
-    @defaulted_property(default="~/.pex")
+    @defaulted_property(default=os.path.join("~", ".pex"))
     def PEX_ROOT(self):
         # type: () -> str
         """Directory.

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -765,7 +765,9 @@ def venv_dir(
         if (
             not ENV.PEX_PYTHON_PATH
             or interpreter_binary.startswith(ENV.PEX_PYTHON_PATH)
-            or os.path.realpath(interpreter_binary).startswith(ENV.PEX_PYTHON_PATH)
+            or os.path.realpath(interpreter_binary).startswith(
+                tuple(os.path.realpath(p) for p in ENV.PEX_PYTHON_PATH)
+            )
         ):
             interpreter_path = interpreter_binary
     if interpreter_path:

--- a/pex/vendor/__main__.py
+++ b/pex/vendor/__main__.py
@@ -220,21 +220,24 @@ def vendorize(root_dir, vendor_specs, prefix, update):
         # NB: We set --no-build-isolation to prevent pip from installing the requirements listed in
         # its [build-system] config in its pyproject.toml.
         #
-        # Those requirements are (currently) the unpinned ["setuptools", "wheel"], which will cause pip
-        # to use the latest version of those packages.  This is a hermeticity problem: re-vendoring a
-        # package at a later time may yield a different result.  At the very least the result will
-        # differ in the version embedded in the WHEEL metadata file, which causes issues with our
-        # tests.
+        # Those requirements are (currently) the unpinned ["setuptools", "wheel"], which will cause
+        # pip to use the latest version of those packages.  This is a hermeticity problem:
+        # re-vendoring a package at a later time may yield a different result.  At the very least
+        # the result will differ in the version embedded in the WHEEL metadata file, which causes
+        # issues with our tests.
         #
         # Setting --no-build-isolation means that versions of setuptools and wheel must be provided
-        # in the environment in which we run the pip command, which is the environment in which we run
-        # pex.vendor. Since we document that pex.vendor should be run via tox, that environment will
-        # contain pinned versions of setuptools and wheel. As a result, vendoring (at least via tox)
-        # is hermetic.
+        # in the environment in which we run the pip command, which is the environment in which we
+        # run pex.vendor. Since we document that pex.vendor should be run via tox, that environment
+        # will contain pinned versions of setuptools and wheel. We further set `--no-cache-dir` so
+        # that Pip finds no newer versions of wheel in its cache. As a result, vendoring (at least
+        # via tox) is hermetic.
         requirement = vendor_spec.prepare()
         cmd = [
             "pip",
             "install",
+            "--no-build-isolation",
+            "--no-cache-dir",
             "--no-compile",
             "--prefix",
             prefix_dir_by_vendor_spec[vendor_spec],

--- a/pex/vendor/_vendored/attrs/attrs-21.5.0.dev0.dist-info/METADATA
+++ b/pex/vendor/_vendored/attrs/attrs-21.5.0.dev0.dist-info/METADATA
@@ -16,6 +16,7 @@ Project-URL: Funding, https://github.com/sponsors/hynek
 Project-URL: Tidelift, https://tidelift.com/subscription/pkg/pypi-attrs?utm_source=pypi-attrs&utm_medium=pypi
 Project-URL: Ko-fi, https://ko-fi.com/the_hynek
 Keywords: class,attribute,boilerplate
+Platform: UNKNOWN
 Classifier: Development Status :: 5 - Production/Stable
 Classifier: Intended Audience :: Developers
 Classifier: Natural Language :: English
@@ -36,8 +37,6 @@ Classifier: Programming Language :: Python :: Implementation :: PyPy
 Classifier: Topic :: Software Development :: Libraries :: Python Modules
 Requires-Python: >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 Description-Content-Type: text/x-rst
-License-File: LICENSE
-License-File: AUTHORS.rst
 Provides-Extra: dev
 Requires-Dist: coverage[toml] (>=5.0.2) ; extra == 'dev'
 Requires-Dist: hypothesis ; extra == 'dev'
@@ -227,3 +226,5 @@ A full list of contributors can be found in `GitHub's overview <https://github.c
 
 It’s the spiritual successor of `characteristic <https://characteristic.readthedocs.io/>`_ and aspires to fix some of it clunkiness and unfortunate decisions.
 Both were inspired by Twisted’s `FancyEqMixin <https://twistedmatrix.com/documents/current/api/twisted.python.util.FancyEqMixin.html>`_ but both are implemented using class decorators because `subclassing is bad for you <https://www.youtube.com/watch?v=3MNVP9-hglc>`_, m’kay?
+
+

--- a/pex/vendor/_vendored/attrs/attrs-21.5.0.dev0.dist-info/WHEEL
+++ b/pex/vendor/_vendored/attrs/attrs-21.5.0.dev0.dist-info/WHEEL
@@ -1,5 +1,5 @@
 Wheel-Version: 1.0
-Generator: bdist_wheel (0.38.3)
+Generator: bdist_wheel (0.35.1)
 Root-Is-Purelib: true
 Tag: py2-none-any
 Tag: py3-none-any

--- a/pex/vendor/_vendored/attrs/attrs-21.5.0.dev0.dist-info/WHEEL
+++ b/pex/vendor/_vendored/attrs/attrs-21.5.0.dev0.dist-info/WHEEL
@@ -1,5 +1,5 @@
 Wheel-Version: 1.0
-Generator: bdist_wheel (0.37.1)
+Generator: bdist_wheel (0.38.3)
 Root-Is-Purelib: true
 Tag: py2-none-any
 Tag: py3-none-any

--- a/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/METADATA
+++ b/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/METADATA
@@ -10,6 +10,7 @@ Project-URL: Documentation, https://pip.pypa.io
 Project-URL: Source, https://github.com/pypa/pip
 Project-URL: Changelog, https://pip.pypa.io/en/stable/news/
 Keywords: distutils easy_install egg setuptools wheel virtualenv
+Platform: UNKNOWN
 Classifier: Development Status :: 5 - Production/Stable
 Classifier: Intended Audience :: Developers
 Classifier: License :: OSI Approved :: MIT License
@@ -26,7 +27,6 @@ Classifier: Programming Language :: Python :: 3.9
 Classifier: Programming Language :: Python :: Implementation :: CPython
 Classifier: Programming Language :: Python :: Implementation :: PyPy
 Requires-Python: >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*
-License-File: LICENSE.txt
 
 pip - The Python Package Installer
 ==================================
@@ -90,3 +90,5 @@ rooms, and mailing lists is expected to follow the `PSF Code of Conduct`_.
 .. _User IRC: https://webchat.freenode.net/?channels=%23pypa
 .. _Development IRC: https://webchat.freenode.net/?channels=%23pypa-dev
 .. _PSF Code of Conduct: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
+
+

--- a/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/WHEEL
+++ b/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/WHEEL
@@ -1,5 +1,5 @@
 Wheel-Version: 1.0
-Generator: bdist_wheel (0.38.3)
+Generator: bdist_wheel (0.35.1)
 Root-Is-Purelib: true
 Tag: py2-none-any
 Tag: py3-none-any

--- a/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/WHEEL
+++ b/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/WHEEL
@@ -1,5 +1,5 @@
 Wheel-Version: 1.0
-Generator: bdist_wheel (0.37.1)
+Generator: bdist_wheel (0.38.3)
 Root-Is-Purelib: true
 Tag: py2-none-any
 Tag: py3-none-any

--- a/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/entry_points.txt
+++ b/pex/vendor/_vendored/pip/pip-20.3.4.dist-info/entry_points.txt
@@ -2,3 +2,4 @@
 pip = pip._internal.cli.main:main
 pip3 = pip._internal.cli.main:main
 pip3.8 = pip._internal.cli.main:main
+

--- a/pex/vendor/_vendored/setuptools/setuptools-44.0.0+3acb925dd708430aeaf197ea53ac8a752f7c1863.dist-info/WHEEL
+++ b/pex/vendor/_vendored/setuptools/setuptools-44.0.0+3acb925dd708430aeaf197ea53ac8a752f7c1863.dist-info/WHEEL
@@ -1,5 +1,5 @@
 Wheel-Version: 1.0
-Generator: bdist_wheel (0.38.3)
+Generator: bdist_wheel (0.35.1)
 Root-Is-Purelib: true
 Tag: py2-none-any
 Tag: py3-none-any

--- a/pex/vendor/_vendored/setuptools/setuptools-44.0.0+3acb925dd708430aeaf197ea53ac8a752f7c1863.dist-info/WHEEL
+++ b/pex/vendor/_vendored/setuptools/setuptools-44.0.0+3acb925dd708430aeaf197ea53ac8a752f7c1863.dist-info/WHEEL
@@ -1,5 +1,5 @@
 Wheel-Version: 1.0
-Generator: bdist_wheel (0.37.1)
+Generator: bdist_wheel (0.38.3)
 Root-Is-Purelib: true
 Tag: py2-none-any
 Tag: py3-none-any

--- a/pex/venv/pex.py
+++ b/pex/venv/pex.py
@@ -470,6 +470,8 @@ def _populate_sources(
                     )
                 )
                 sys.exit(1)
+            is_exec_override = len(pex_overrides) == 1
+
             if {strip_pex_env!r}:
                 for key in list(os.environ):
                     if key.startswith("PEX_"):
@@ -559,6 +561,11 @@ def _populate_sources(
                     {exec_ast}
                     sys.exit(0)
 
+            if not is_exec_override:
+                for name, value in {inject_env!r}:
+                    os.environ.setdefault(name, value)
+                sys.argv[1:1] = {inject_args!r}
+
             module_name, _, function = entry_point.partition(":")
             if not function:
                 import runpy
@@ -578,6 +585,8 @@ def _populate_sources(
             shebang_python=venv_python,
             bin_path=bin_path,
             strip_pex_env=pex_info.strip_pex_env,
+            inject_env=tuple(pex_info.inject_env.items()),
+            inject_args=list(pex_info.inject_args),
             entry_point=pex_info.entry_point,
             script=pex_info.script,
             exec_ast=(

--- a/pex/venv/pex.py
+++ b/pex/venv/pex.py
@@ -103,6 +103,7 @@ def populate_venv(
     collisions_ok=True,  # type: bool
     symlink=False,  # type: bool
     scope=InstallScope.ALL,  # type: InstallScope.Value
+    hermetic_scripts=True,  # type: bool
 ):
     # type: (...) -> str
 
@@ -117,7 +118,7 @@ def populate_venv(
             provenance[dst].append(src)
 
     if scope in (InstallScope.ALL, InstallScope.DEPS_ONLY):
-        record_provenance(_populate_deps(venv, pex, venv_python, symlink))
+        record_provenance(_populate_deps(venv, pex, venv_python, symlink, hermetic_scripts))
 
     if scope in (InstallScope.ALL, InstallScope.SOURCE_ONLY):
         record_provenance(_populate_sources(venv, pex, shebang, venv_python, bin_path))
@@ -195,6 +196,7 @@ def _populate_deps(
     pex,  # type: PEX
     venv_python,  # type: str
     symlink=False,  # type: bool
+    hermetic_scripts=True,  # type: bool
 ):
     # type: (...) -> Iterator[Tuple[str, str]]
 
@@ -274,7 +276,8 @@ def _populate_deps(
                     print(rel_extra_path, file=fp)
 
     # 3. Re-write any (console) scripts to use the venv Python.
-    for script in venv.rewrite_scripts(python=venv_python, python_args="-sE"):
+    script_python_args = "-sE" if hermetic_scripts else None
+    for script in venv.rewrite_scripts(python=venv_python, python_args=script_python_args):
         TRACER.log("Re-writing {}".format(script))
 
 

--- a/pex/venv/pex.py
+++ b/pex/venv/pex.py
@@ -426,6 +426,8 @@ def _populate_sources(
                     # These are used by Pex's Pip venv to implement universal locks.
                     "_PEX_PYTHON_VERSIONS_FILE",
                     "_PEX_TARGET_SYSTEMS_FILE",
+                    # This is used as an experiment knob for atomic_directory locking.
+                    "_PEX_FILE_LOCK_STYLE",
                 )
             ]
             if ignored_pex_env_vars:

--- a/pex/venv/pex.py
+++ b/pex/venv/pex.py
@@ -440,9 +440,6 @@ def _populate_sources(
 
             os.environ["VIRTUAL_ENV"] = venv_dir
 
-            # A Python interpreter always inserts the CWD at the head of the sys.path.
-            sys.path.insert(0, "")
-
             bin_path = os.environ.get("PEX_VENV_BIN_PATH", {bin_path!r})
             if bin_path != "false":
                 PATH = os.environ.get("PATH", "").split(os.pathsep)
@@ -498,6 +495,12 @@ def _populate_sources(
                 if pex_interpreter
                 else pex_overrides.get("PEX_MODULE", {entry_point!r} or PEX_INTERPRETER_ENTRYPOINT)
             )
+
+            if entry_point == PEX_INTERPRETER_ENTRYPOINT:
+                # A Python interpreter always inserts the CWD at the head of the sys.path.
+                # See https://docs.python.org/3/library/sys.html#sys.path
+                sys.path.insert(0, "")
+
             if entry_point == PEX_INTERPRETER_ENTRYPOINT and len(sys.argv) > 1:
                 args = sys.argv[1:]
 

--- a/pex/venv/virtualenv.py
+++ b/pex/venv/virtualenv.py
@@ -12,7 +12,8 @@ import sys
 from contextlib import closing
 from fileinput import FileInput
 
-from pex.common import AtomicDirectory, atomic_directory, is_exe, safe_mkdir, safe_open
+from pex.atomic_directory import AtomicDirectory, atomic_directory
+from pex.common import is_exe, safe_mkdir, safe_open
 from pex.compatibility import commonpath, get_stdout_bytes_buffer
 from pex.dist_metadata import Distribution, find_distributions
 from pex.executor import Executor
@@ -366,7 +367,7 @@ class Virtualenv(object):
                 url_rel_path = get_pip_script
                 dst_rel_path = os.path.join("default", get_pip_script)
             get_pip = os.path.join(ENV.PEX_ROOT, "get-pip", dst_rel_path)
-            with atomic_directory(os.path.dirname(get_pip), exclusive=True) as atomic_dir:
+            with atomic_directory(os.path.dirname(get_pip)) as atomic_dir:
                 if not atomic_dir.is_finalized():
                     with URLFetcher().get_body_stream(
                         "https://bootstrap.pypa.io/pip/" + url_rel_path

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.1.110"
+__version__ = "2.1.111"

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.1.119"
+__version__ = "2.1.120"

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.1.112"
+__version__ = "2.1.113"

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.1.109"
+__version__ = "2.1.110"

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.1.111"
+__version__ = "2.1.112"

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.1.113"
+__version__ = "2.1.114"

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.1.116"
+__version__ = "2.1.117"

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.1.115"
+__version__ = "2.1.116"

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.1.114"
+__version__ = "2.1.115"

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.1.118"
+__version__ = "2.1.119"

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.1.117"
+__version__ = "2.1.118"

--- a/tests/bin/test_sh_boot.py
+++ b/tests/bin/test_sh_boot.py
@@ -136,11 +136,14 @@ def test_calculate_no_targets_ics():
     assert (
         expected(
             PythonBinaryName(name="python", version=(3, 7)),
-            PythonBinaryName(name="python", version=(3, 8)),
-            PythonBinaryName(name="python", version=(3, 9)),
             PythonBinaryName(name="pypy", version=(3, 7)),
+            PythonBinaryName(name="python", version=(3, 8)),
+            PythonBinaryName(name="pypy", version=(3, 8)),
+            PythonBinaryName(name="python", version=(3, 9)),
+            PythonBinaryName(name="pypy", version=(3, 9)),
+            PythonBinaryName(name="pypy", version=(3, 6)),
         )
-        == calculate_binary_names(interpreter_constraints=[">=3.7,<3.10", "PyPy==3.7.*"])
+        == calculate_binary_names(interpreter_constraints=[">=3.7,<3.10", "PyPy==3.6.*"])
     )
 
 

--- a/tests/integration/cli/commands/test_export.py
+++ b/tests/integration/cli/commands/test_export.py
@@ -118,6 +118,54 @@ def test_export_single_artifact(tmpdir):
     )
 
 
+def test_export_normalizes_name_but_not_version(tmpdir):
+    # type: (Any) -> None
+
+    assert dedent(
+        """\
+             twitter-common-decorators==1.3.0 \\
+               --hash=md5:abcd1234 \\
+               --hash=sha1:ef567890
+            """
+    ) == export(
+        tmpdir,
+        attr.evolve(
+            UNIVERSAL_ANSICOLORS,
+            requirements=SortedTuple([Requirement.parse("twitter.common.decorators")]),
+            locked_resolves=SortedTuple(
+                [
+                    LockedResolve(
+                        locked_requirements=SortedTuple(
+                            [
+                                LockedRequirement(
+                                    pin=Pin(
+                                        ProjectName("twitter.common.decorators"),
+                                        Version("1.3.0"),
+                                    ),
+                                    artifact=Artifact.from_url(
+                                        url="http://localhost:9999/twitter.common.decorators-1.3.0-py2.py3-none-any.whl",
+                                        fingerprint=Fingerprint(algorithm="md5", hash="abcd1234"),
+                                    ),
+                                    additional_artifacts=SortedTuple(
+                                        [
+                                            Artifact.from_url(
+                                                url="http://localhost:9999/twitter.common.decorators-1.3.0.tar.gz",
+                                                fingerprint=Fingerprint(
+                                                    algorithm="sha1", hash="ef567890"
+                                                ),
+                                            )
+                                        ]
+                                    ),
+                                )
+                            ],
+                        ),
+                    )
+                ]
+            ),
+        ),
+    )
+
+
 def test_export_respects_target(tmpdir):
     # type: (Any) -> None
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,7 +10,8 @@ from textwrap import dedent
 
 import pytest
 
-from pex.common import atomic_directory, safe_mkdtemp, temporary_dir
+from pex.atomic_directory import atomic_directory
+from pex.common import safe_mkdtemp, temporary_dir
 from pex.testing import PY310, ensure_python_venv, make_env, run_pex_command
 from pex.typing import TYPE_CHECKING
 
@@ -48,7 +49,7 @@ def pex_bdist(
     # type: (...) -> str
     pex_bdist_chroot = os.path.join(shared_integration_test_tmpdir, "pex_bdist_chroot")
     wheels_dir = os.path.join(pex_bdist_chroot, "wheels_dir")
-    with atomic_directory(pex_bdist_chroot, exclusive=True) as chroot:
+    with atomic_directory(pex_bdist_chroot) as chroot:
         if not chroot.is_finalized():
             pex_pex = os.path.join(chroot.work_dir, "pex.pex")
             run_pex_command(

--- a/tests/integration/test_inject_env_and_args.py
+++ b/tests/integration/test_inject_env_and_args.py
@@ -1,0 +1,301 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import hashlib
+import json
+import os.path
+import re
+import signal
+import socket
+import subprocess
+from contextlib import closing
+from textwrap import dedent
+
+import pytest
+
+from pex.common import safe_open
+from pex.fetcher import URLFetcher
+from pex.testing import IS_PYPY, PY_VER, make_env, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Iterable, List, Optional
+
+
+def test_inject_env_invalid():
+    # type: () -> None
+    result = run_pex_command(args=["--inject-env", "FOO"])
+    result.assert_failure()
+    assert "--inject-env" in result.error
+    assert (
+        "Environment variable values must be of the form `name=value`. Given: FOO" in result.error
+    )
+
+
+parametrize_execution_mode_args = pytest.mark.parametrize(
+    "execution_mode_args",
+    [
+        pytest.param([], id="ZIPAPP"),
+        pytest.param(["--venv"], id="VENV"),
+    ],
+)
+
+
+@parametrize_execution_mode_args
+def test_inject_env(
+    tmpdir,  # type: Any
+    execution_mode_args,  # type: List[str]
+):
+    # type: (...) -> None
+
+    print_FOO_env_code = "import os; print(os.environ.get('FOO', '<not set>'))"
+
+    pex = os.path.join(str(tmpdir), "pex")
+    with open(os.path.join(str(tmpdir), "exe.py"), "w") as fp:
+        fp.write(print_FOO_env_code)
+    run_pex_command(
+        args=["--inject-env", "FOO=bar", "--exe", fp.name, "-o", pex] + execution_mode_args
+    ).assert_success()
+
+    def assert_FOO(
+        expected_env_value,  # type: str
+        runtime_env_value=None,  # type: Optional[str]
+    ):
+        assert (
+            expected_env_value
+            == subprocess.check_output(args=[pex], env=make_env(FOO=runtime_env_value))
+            .decode("utf-8")
+            .strip()
+        )
+
+    assert_FOO(expected_env_value="bar")
+    assert_FOO(expected_env_value="baz", runtime_env_value="baz")
+    assert_FOO(expected_env_value="", runtime_env_value="")
+
+    # Switching away from the built-in entrypoint should disable the injected env.
+    assert (
+        "<not set>"
+        == subprocess.check_output(
+            args=[pex, "-c", print_FOO_env_code], env=make_env(PEX_INTERPRETER=1)
+        )
+        .decode("utf-8")
+        .strip()
+    )
+
+
+DUMP_ARGS_CODE = "import json, sys; print(json.dumps(sys.argv[1:]))"
+
+
+def create_inject_args_pex(
+    tmpdir,  # type: Any
+    execution_mode_args,  # type: Iterable[str]
+    *inject_args  # type: str
+):
+    # type: (...) -> str
+    pex = os.path.join(
+        str(tmpdir),
+        "pex-{}".format(hashlib.sha256(json.dumps(inject_args).encode("utf-8")).hexdigest()),
+    )
+    with open(os.path.join(str(tmpdir), "exe.py"), "w") as fp:
+        fp.write(DUMP_ARGS_CODE)
+    argv = ["--exe", fp.name, "-o", pex]
+    for inject in inject_args:
+        argv.append("--inject-args")
+        argv.append(inject)
+    argv.extend(execution_mode_args)
+    run_pex_command(args=argv).assert_success()
+    return pex
+
+
+@parametrize_execution_mode_args
+def test_inject_args(
+    tmpdir,  # type: Any
+    execution_mode_args,  # type: List[str]
+):
+    # type: (...) -> None
+
+    pex_individual = create_inject_args_pex(tmpdir, execution_mode_args, "foo", "bar")
+    pex_shlex = create_inject_args_pex(tmpdir, execution_mode_args, "foo bar")
+    pex_combined = create_inject_args_pex(tmpdir, execution_mode_args, "foo bar", "baz")
+
+    def assert_argv(
+        pex,  # type: str
+        expected_argv,  # type: List[str]
+        runtime_args=(),  # type: Iterable[str]
+        **env
+    ):
+        assert expected_argv == json.loads(
+            subprocess.check_output(args=[pex] + list(runtime_args), env=make_env(**env))
+        )
+
+    assert_argv(pex_individual, expected_argv=["foo", "bar"])
+    assert_argv(pex_individual, expected_argv=["foo", "bar", "baz"], runtime_args=["baz"])
+    assert_argv(pex_shlex, expected_argv=["foo", "bar"])
+    assert_argv(pex_shlex, expected_argv=["foo", "bar", "baz"], runtime_args=["baz"])
+    assert_argv(pex_combined, expected_argv=["foo", "bar", "baz"])
+    assert_argv(pex_combined, expected_argv=["foo", "bar", "baz", "baz"], runtime_args=["baz"])
+
+    # Switching away from the built-in entrypoint should disable injected args.
+    assert_argv(
+        pex_individual, expected_argv=[], runtime_args=["-c", DUMP_ARGS_CODE], PEX_INTERPRETER=1
+    )
+    assert_argv(pex_shlex, expected_argv=[], runtime_args=["-c", DUMP_ARGS_CODE], PEX_INTERPRETER=1)
+    assert_argv(
+        pex_combined, expected_argv=[], runtime_args=["-c", DUMP_ARGS_CODE], PEX_INTERPRETER=1
+    )
+
+
+@pytest.mark.skipif(PY_VER < (3, 7), reason="Uvicorn only support Python 3.7+.")
+@parametrize_execution_mode_args
+def test_complex(
+    tmpdir,  # type: Any
+    execution_mode_args,  # type: List[str]
+):
+    # type: (...) -> None
+
+    pex = os.path.join(str(tmpdir), "pex")
+    src = os.path.join(str(tmpdir), "src")
+    with safe_open(os.path.join(src, "example.py"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                import json
+                import os
+                import sys
+
+
+                async def app(scope, receive, send):
+                    assert scope['type'] == 'http'
+
+                    await send({
+                        'type': 'http.response.start',
+                        'status': 200,
+                        'headers': [
+                            [b'content-type', b'text/plain'],
+                        ],
+                    })
+                    await send({
+                        'type': 'http.response.body',
+                        'body': os.environb.get(b'MESSAGE') or b'<message unset>',
+                    })
+
+                if __name__ == "__main__":
+                    json.dump(
+                        {"args": sys.argv[1:], "MESSAGE": os.environ.get("MESSAGE")}, sys.stdout
+                    )
+                """
+            )
+        )
+    run_pex_command(
+        args=[
+            "-D",
+            src,
+            "uvicorn[standard]==0.18.3",
+            "-c",
+            "uvicorn",
+            "--inject-args",
+            "example:app",
+            "--inject-env",
+            "MESSAGE=Hello, world!",
+            "-o",
+            pex,
+        ]
+        + execution_mode_args
+    ).assert_success()
+
+    def assert_message(
+        expected,  # type: bytes
+        **env  # type: str
+    ):
+        # type: (...) -> None
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+            sock.bind(("127.0.0.1", 0))
+            stderr_read_fd, stderr_write_fd = os.pipe()
+            # Python 2.7 doesn't support pass_fds, but we don't test against Python2.7.
+            process = subprocess.Popen(  # type: ignore[call-arg]
+                args=[pex, "--fd", str(sock.fileno())],
+                stderr=stderr_write_fd,
+                pass_fds=[sock.fileno()],
+                env=make_env(**env),
+            )
+            with os.fdopen(stderr_read_fd, "r") as stderr_fp:
+                for line in stderr_fp:
+                    if "Uvicorn running" in line:
+                        break
+
+            host, port = sock.getsockname()
+            with URLFetcher().get_body_stream(
+                "http://{host}:{port}".format(host=host, port=port)
+            ) as fp:
+                assert expected == fp.read()
+            process.send_signal(signal.SIGINT)
+            process.kill()
+            os.close(stderr_write_fd)
+
+    assert_message(b"Hello, world!")
+    assert_message(b"42", MESSAGE="42")
+
+    # Switching away from the built-in entrypoint should disable injected args and env.
+    assert {"args": ["foo", "bar"], "MESSAGE": None} == json.loads(
+        subprocess.check_output(args=[pex, "foo", "bar"], env=make_env(PEX_MODULE="example"))
+    )
+
+
+@pytest.mark.skipif(
+    IS_PYPY or PY_VER > (3, 10) or PY_VER < (3, 6),
+    reason="The pyuwsgi distribution only has wheels for Linux and Mac for Python 3.6 through 3.10",
+)
+@parametrize_execution_mode_args
+def test_pyuwsgi(
+    tmpdir,  # type: Any
+    execution_mode_args,  # type: List[str]
+):
+    # type: (...) -> None
+
+    pex = os.path.join(str(tmpdir), "pex")
+    src = os.path.join(str(tmpdir), "src")
+    with safe_open(os.path.join(src, "myflaskapp.py"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                from flask import Flask
+
+                app = Flask(__name__)
+
+                @app.route('/')
+                def index():
+                    return "I am app 1"
+                """
+            )
+        )
+    run_pex_command(
+        args=[
+            "-D",
+            src,
+            "pyuwsgi",
+            "flask",
+            "-c",
+            "uwsgi",
+            "--inject-args",
+            "--master --module myflaskapp:app",
+            "-o",
+            pex,
+        ]
+        + execution_mode_args
+    ).assert_success()
+
+    stderr_read_fd, stderr_write_fd = os.pipe()
+    process = subprocess.Popen(args=[pex, "--http-socket", "127.0.0.1:0"], stderr=stderr_write_fd)
+    port = None  # type: Optional[str]
+    with os.fdopen(stderr_read_fd, "r") as stderr_fp:
+        for line in stderr_fp:
+            match = re.search(r"bound to TCP address 127.0.0.1:(?P<port>\d+)", line)
+            if match:
+                port = match.group("port")
+                break
+    assert port is not None, "Could not determine uwsgi server port."
+    with URLFetcher().get_body_stream("http://127.0.0.1:{port}".format(port=port)) as fp:
+        assert b"I am app 1" == fp.read()
+    process.send_signal(signal.SIGINT)
+    process.kill()
+    os.close(stderr_write_fd)

--- a/tests/integration/test_interpreter_selection.py
+++ b/tests/integration/test_interpreter_selection.py
@@ -370,8 +370,8 @@ def test_pex_python():
         assert py310 in stdout.decode("utf-8")
 
 
-def test_interpreter_selection_using_os_environ_for_bootstrap_reexec():
-    # type: () -> None
+def test_interpreter_selection_using_os_environ_for_bootstrap_reexec(pex_project_dir):
+    # type: (str) -> None
     """This is a test for verifying the proper function of the pex bootstrapper's interpreter
     selection logic and validate a corresponding bugfix.
 
@@ -459,7 +459,15 @@ def test_interpreter_selection_using_os_environ_for_bootstrap_reexec():
 
         pex_out_path = os.path.join(td, "parent.pex")
         res = run_pex_command(
-            ["--disable-cache", "pex", "{}".format(td), "-e", "testing:tester", "-o", pex_out_path]
+            [
+                "--disable-cache",
+                pex_project_dir,
+                "{}".format(td),
+                "-e",
+                "testing:tester",
+                "-o",
+                pex_out_path,
+            ]
         )
         res.assert_success()
 

--- a/tests/integration/test_issue_1017.py
+++ b/tests/integration/test_issue_1017.py
@@ -1,21 +1,32 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
+
+from pex.common import temporary_dir
 from pex.testing import PY38, ensure_python_interpreter, run_pex_command
 
 
 def test_resolve_python_requires_full_version():
     # type: () -> None
     python38 = ensure_python_interpreter(PY38)
-    result = run_pex_command(
-        python=python38,
-        args=[
-            "pandas==1.0.5",
-            "--",
-            "-c",
-            "import pandas; print(pandas._version.get_versions()['version'])",
-        ],
-        quiet=True,
-    )
+    with temporary_dir() as tmpdir:
+        constraints_file = os.path.join(tmpdir, "constraints.txt")
+        with open(constraints_file, "w") as fp:
+            # pandas 1.0.5 has an open-ended requirement on numpy, but is in practice
+            # incompatible with numpy>=1.24.0 because it drops np.bool support.
+            fp.write("numpy==1.23.5")
+        result = run_pex_command(
+            python=python38,
+            args=[
+                "pandas==1.0.5",
+                "--constraints",
+                constraints_file,
+                "--",
+                "-c",
+                "import pandas; print(pandas._version.get_versions()['version'])",
+            ],
+            quiet=True,
+        )
     result.assert_success()
     assert "1.0.5" == result.output.strip()

--- a/tests/integration/test_issue_1730.py
+++ b/tests/integration/test_issue_1730.py
@@ -1,7 +1,7 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import os
 
@@ -24,11 +24,17 @@ def test_check_install_issue_1730(
     # type: (...) -> None
 
     pex_root = os.path.join(str(tmpdir), "pex_root")
+    constraints = os.path.join(str(tmpdir), "constraints.txt")
+    with open(constraints, "w") as fp:
+        print("packaging==21.3", file=fp)
+
     pex_args = [
         "--pex-root",
         pex_root,
         "--runtime-pex-root",
         pex_root,
+        "--constraints",
+        constraints,
         "pantsbuild.pants.testutil==2.12.0.dev3",
         "--",
         "-c",

--- a/tests/integration/test_issue_1949.py
+++ b/tests/integration/test_issue_1949.py
@@ -1,0 +1,107 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import os.path
+
+import pytest
+
+from pex.cli.testing import run_pex3
+from pex.compatibility import commonpath
+from pex.testing import IntegResults, built_wheel, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Iterator
+
+
+@pytest.fixture
+def wheel():
+    # type: () -> Iterator[str]
+    with built_wheel(name="not_boto", version="2.49.0a1") as whl:
+        yield whl
+
+
+def test_resolve_arbitrary_equality(
+    tmpdir,  # type: Any
+    wheel,  # type: str
+):
+    # type: (...) -> None
+
+    lock = os.path.join(str(tmpdir), "lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--no-pypi",
+        "--find-links",
+        os.path.dirname(wheel),
+        "not_boto===2.49.0a1",
+        "--indent",
+        "2",
+        "-o",
+        lock,
+    ).assert_success()
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+
+    def create_pex_from_lock(*additional_args):
+        # type: (*str) -> IntegResults
+        return run_pex_command(
+            args=[
+                "--pex-root",
+                pex_root,
+                "--runtime-pex-root",
+                pex_root,
+                "--lock",
+                lock,
+            ]
+            + list(additional_args)
+            + ["--", "-c", "import not_boto; print(not_boto.__file__)"]
+        )
+
+    result = create_pex_from_lock()
+    result.assert_success()
+    assert pex_root == commonpath((pex_root, result.output.strip()))
+
+    result = create_pex_from_lock("not_boto===2.49.0a1")
+    result.assert_success()
+    assert pex_root == commonpath((pex_root, result.output.strip()))
+
+    result = create_pex_from_lock("not_boto===2.49a1")
+    result.assert_failure()
+
+    pex_repository = os.path.join(str(tmpdir), "pex_repository")
+    run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--lock",
+            lock,
+            "-o",
+            pex_repository,
+        ]
+    ).assert_success()
+
+    def create_pex_from_pex_repository(requirement):
+        # type: (str) -> IntegResults
+        return run_pex_command(
+            args=[
+                "--pex-root",
+                pex_root,
+                "--runtime-pex-root",
+                pex_root,
+                "--pex-repository",
+                pex_repository,
+                requirement,
+                "--",
+                "-c",
+                "import not_boto; print(not_boto.__file__)",
+            ]
+        )
+
+    result = create_pex_from_pex_repository("not_boto===2.49.0a1")
+    result.assert_success()
+    assert pex_root == commonpath((pex_root, result.output.strip()))
+
+    result = create_pex_from_pex_repository("not_boto===2.49a1")
+    result.assert_failure()

--- a/tests/integration/test_issue_1995.py
+++ b/tests/integration/test_issue_1995.py
@@ -1,0 +1,40 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+import subprocess
+import sys
+
+from pex.testing import PY38, ensure_python_interpreter, make_env, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_packaging(
+    tmpdir,  # type: Any
+    pex_project_dir,  # type: str
+):
+    # type: (...) -> None
+    pex = os.path.join(str(tmpdir), "pex.pex")
+    package_script = os.path.join(pex_project_dir, "scripts", "package.py")
+    run_pex_command(
+        args=[
+            "toml",
+            pex_project_dir,
+            "--",
+            package_script,
+            "-v",
+            "--pex-output-file",
+            pex,
+        ],
+        # The package script requires Python 3.
+        python=sys.executable if sys.version_info[0] >= 3 else ensure_python_interpreter(PY38),
+    ).assert_success()
+    assert os.path.exists(pex), "Expected {pex} to be created by {package_script}.".format(
+        pex=pex, package_script=package_script
+    )
+    # The packaged Pex PEX should work with all Pythons we support, including the current test
+    # interpreter.
+    subprocess.check_call(args=[sys.executable, pex, "-V"], env=make_env(PEX_PYTHON=sys.executable))

--- a/tests/integration/test_issue_2001.py
+++ b/tests/integration/test_issue_2001.py
@@ -1,0 +1,44 @@
+import os.path
+import subprocess
+import sys
+
+from pex.testing import make_env, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_compile_error_as_warning(
+    tmpdir,  # type: Any
+):
+    # type: (...) -> None
+    pex = os.path.join(str(tmpdir), "pex.pex")
+    run_pex_command(
+        args=[
+            "--include-tools",
+            "aenum==3.1.11",
+            "-o",
+            pex,
+        ],
+        python=sys.executable,
+    ).assert_success()
+    # The packaged Pex PEX should work with all Pythons we support, including the current test
+    # interpreter.
+    python_version = sys.version_info[0]
+    compiled_deps_dir = str(tmpdir)
+    process = subprocess.Popen(
+        args=[sys.executable, pex, "venv", "--scope", "deps", "--compile", compiled_deps_dir],
+        env=make_env(PEX_PYTHON=sys.executable, PEX_TOOLS=1),
+        stderr=subprocess.PIPE,
+    )
+    _, stderr_bytes = process.communicate()
+    assert 0 == process.returncode
+
+    stderr_str = stderr_bytes.decode("utf-8")
+    if python_version == 2:
+        assert not stderr_str, "No PEXWarning should be generated for python2"
+    else:
+        assert (
+            "PEXWarning: ignoring compile error" in stderr_str
+        ), "PEXWarning should be generated for python3."

--- a/tests/integration/test_issue_2006.py
+++ b/tests/integration/test_issue_2006.py
@@ -1,0 +1,70 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+import subprocess
+import sys
+
+import pytest
+
+from pex.compatibility import PY3
+from pex.testing import PY38, ensure_python_interpreter, run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, List
+
+
+@pytest.mark.parametrize(
+    ["boot_args"],
+    [
+        pytest.param([], id="__main__.py boot"),
+        pytest.param(["--sh-boot"], id="--sh-boot"),
+    ],
+)
+def test_symlink_preserved_in_argv0(
+    tmpdir,  # type: Any
+    boot_args,  # type: List[str]
+):
+    # type: (...) -> None
+
+    # N.B.: We use conscript (https://pypi.org/project/conscript/) here to test a very common real
+    # use case for knowing the original path used to launch an executable. In general this allows
+    # the executable to react differently based on its name. In the conscript case, it uses that
+    # name to select a matching console script in the PEX if one exists and run that. If no such
+    # match exists and there are no args, it launches a REPL session over the PEX contents.
+
+    pex = os.path.join(str(tmpdir), "speak.pex")
+    run_pex_command(
+        args=["conscript==0.1.5", "cowsay==5.0", "fortune==1.1.0", "-c", "conscript", "-o", pex]
+        + boot_args
+    ).assert_success()
+
+    assert (
+        "5.0" == subprocess.check_output(args=[pex, "cowsay", "--version"]).decode("utf-8").strip()
+    )
+
+    cowsay = os.path.join(str(tmpdir), "cowsay")
+    os.symlink(pex, cowsay)
+    assert "5.0" == subprocess.check_output(args=[cowsay, "--version"]).decode("utf-8").strip(), (
+        "Expected the symlink used to launch this PEX to be preserved in sys.argv[0] such that "
+        "conscript could observe it and select the cowsay console script inside the PEX for"
+        "execution. Without symlink preservation, the real PEX name of speak.pex will match no "
+        "internal console scripts and the conscript entry point will drop into a REPL session over "
+        "the PEX causing this test to hang waiting for a REPL session exit signal / command."
+    )
+
+    fortune_file = os.path.join(str(tmpdir), "fortunes.txt")
+    with open(fortune_file, "w") as fp:
+        fp.write("Just the one")
+    fortune = os.path.join(str(tmpdir), "fortune")
+    os.symlink(pex, fortune)
+
+    # N.B.: This fortune implementation uses print(..., file=...) without
+    # `from __future__ import print_function`; so fails under Python 2.7 despite the fact its
+    # released as a py2.py3 wheel.
+    python = sys.executable if PY3 else ensure_python_interpreter(PY38)
+    assert (
+        "Just the one"
+        == subprocess.check_output(args=[python, fortune, fortune_file]).decode("utf-8").strip()
+    )

--- a/tests/integration/test_issue_2023.py
+++ b/tests/integration/test_issue_2023.py
@@ -1,0 +1,83 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+import shutil
+import subprocess
+import sys
+from textwrap import dedent
+
+import pytest
+from colors import colors
+
+from pex.layout import Layout
+from pex.testing import run_pex_command
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, List
+
+
+@pytest.mark.parametrize(
+    "layout", [pytest.param(layout, id=layout.value) for layout in Layout.values()]
+)
+@pytest.mark.parametrize(
+    "execution_mode_args",
+    [
+        pytest.param([], id="UNZIP"),
+        pytest.param(["--venv", "--venv-site-packages-copies"], id="VENV (copies)"),
+        pytest.param(["--venv", "--no-venv-site-packages-copies"], id="VENV (symlinks)"),
+    ],
+)
+def test_unpack_robustness(
+    tmpdir,  # type: Any
+    layout,  # type: Layout.Value
+    execution_mode_args,  # type: List[str]
+):
+    # type: (...) -> None
+    exe = os.path.join(str(tmpdir), "exe.py")
+    with open(exe, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                import colors
+
+                print(colors.cyan("Wowbagger hasn't gotten to me yet."))
+                """
+            )
+        )
+
+    pex = os.path.join(str(tmpdir), "pex")
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    run_pex_command(
+        args=[
+            "--runtime-pex-root",
+            pex_root,
+            "ansicolors==1.1.8",
+            "--exe",
+            exe,
+            "--layout",
+            layout.value,
+            "-o",
+            pex,
+        ]
+        + execution_mode_args
+    ).assert_success()
+
+    def assert_pex_works(pex_path):
+        # type: (str) -> None
+        assert (
+            colors.cyan("Wowbagger hasn't gotten to me yet.")
+            == subprocess.check_output(args=[sys.executable, pex_path]).decode("utf-8").strip()
+        )
+
+    assert_pex_works(pex)
+
+    elsewhere = os.path.join(str(tmpdir), "elsewhere")
+    os.mkdir(elsewhere)
+    dest = os.path.join(elsewhere, "other")
+    shutil.move(pex, dest)
+    assert_pex_works(dest)
+
+    shutil.rmtree(pex_root)
+    assert_pex_works(dest)

--- a/tests/integration/test_issue_729.py
+++ b/tests/integration/test_issue_729.py
@@ -41,6 +41,7 @@ def test_undeclared_setuptools_import_on_pex_path(tmpdir):
     constraints = os.path.join(str(tmpdir), "constraints.txt")
     with open(constraints, "w") as fp:
         print("google-api-core==1.32.0", file=fp)
+        print("googleapis-common-protos<=1.56.4", file=fp)
         print("google-crc32c==1.1.2", file=fp)
         print("protobuf<=3.17.3", file=fp)
 

--- a/tests/integration/test_pex_import.py
+++ b/tests/integration/test_pex_import.py
@@ -10,9 +10,13 @@ import colors
 import pytest
 
 from pex.common import safe_open
+from pex.interpreter import PythonInterpreter
 from pex.layout import DEPS_DIR, Layout
+from pex.resolve.pex_repository_resolver import resolve_from_pex
+from pex.targets import Targets
 from pex.testing import make_env, run_pex_command
 from pex.typing import TYPE_CHECKING
+from pex.variables import ENV
 
 if TYPE_CHECKING:
     from typing import Any, List, Text
@@ -74,9 +78,34 @@ def test_import_from_pex(
             .strip()
         )
 
-    # Verify 3rd party code can be imported.
+    # Verify 3rd party code can be imported hermetically from the PEX.
+    alternate_pex_root = os.path.join(str(tmpdir), "alternate_pex_root")
+    with ENV.patch(PEX_ROOT=alternate_pex_root):
+        ambient_sys_path = [
+            installed_distribution.fingerprinted_distribution.distribution.location
+            for installed_distribution in resolve_from_pex(
+                targets=Targets(interpreters=(PythonInterpreter.from_binary(sys.executable),)),
+                pex=pex,
+                requirements=["ansicolors==1.1.8"],
+            ).installed_distributions
+        ]
+
     third_party_path = execute_with_pex_on_pythonpath(
-        "from __pex__ import colors; print(colors.__file__)"
+        dedent(
+            """\
+            # Executor code like the AWS runtime.
+            import sys
+            
+            sys.path = {ambient_sys_path!r} + sys.path
+            
+            # User code residing in the PEX.
+            from __pex__ import colors
+            
+            print(colors.__file__)
+            """.format(
+                ambient_sys_path=ambient_sys_path
+            )
+        )
     )
     if is_venv:
         expected_prefix = os.path.join(pex_root, "venvs")
@@ -86,7 +115,7 @@ def test_import_from_pex(
         expected_prefix = os.path.join(pex_root, "installed_wheels")
     assert third_party_path.startswith(
         expected_prefix
-    ), "Expected 3rdp party ansicolors path {path} to start with {expected_prefix}".format(
+    ), "Expected 3rd party ansicolors path {path} to start with {expected_prefix}".format(
         path=third_party_path, expected_prefix=expected_prefix
     )
 

--- a/tests/integration/test_setproctitle.py
+++ b/tests/integration/test_setproctitle.py
@@ -3,6 +3,7 @@
 import os.path
 import subprocess
 import sys
+import sysconfig
 from textwrap import dedent
 from typing import Text
 
@@ -10,10 +11,11 @@ import pytest
 
 from pex import variables
 from pex.common import safe_open
+from pex.compatibility import commonpath
 from pex.interpreter import PythonInterpreter
 from pex.layout import Layout
 from pex.pex_info import PexInfo
-from pex.testing import run_pex_command
+from pex.testing import IS_MAC, run_pex_command
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -90,10 +92,33 @@ def test_setproctitle(
 
     def assert_expected_python(exe):
         # type: (Text) -> None
-        assert (
-            PythonInterpreter.get().resolve_base_interpreter()
-            == PythonInterpreter.from_binary(str(exe)).resolve_base_interpreter()
-        )
+        expected = PythonInterpreter.get().resolve_base_interpreter()
+        actual = PythonInterpreter.from_binary(str(exe)).resolve_base_interpreter()
+        python_framework = sysconfig.get_config_var("PYTHONFRAMEWORKINSTALLDIR")
+        if IS_MAC and expected != actual and python_framework:
+            # Mac framework Python distributions have two Python binaries (starred) as well as
+            # several symlinks. The layout looks like so:
+            #   /Library/Frameworks/
+            #       Python.framework/  # sysconfig.get_config_var("PYTHONFRAMEWORKINSTALLDIR")
+            #           Versions/X.Y/  # sys.prefix
+            #               bin/
+            #                   python -> pythonX.Y
+            #                   pythonX -> pythonX.Y
+            #                   *pythonX.Y
+            #           Resources/Python.app/
+            #               Contents/MacOS/
+            #                   *Python
+            #
+            # In some versions of Python, the bin Python, when executed, gets a sys.executable of
+            # the corresponding Python resource. On others, they each retain a sys.executable
+            # faithful to their launcher file path. It's the latter type we're working around here.
+            assert python_framework == commonpath(
+                (python_framework, expected.binary, actual.binary)
+            )
+            assert expected.prefix == actual.prefix
+            assert expected.version == actual.version
+        else:
+            assert expected == actual
 
     pex_file = os.path.join(str(tmpdir), "pex.file")
     exe, args = grab_ps(pex_file)

--- a/tests/integration/tools/commands/test_venv.py
+++ b/tests/integration/tools/commands/test_venv.py
@@ -265,3 +265,80 @@ def test_scope_issue_1631(tmpdir):
     assert canonical_venv_listing == recursive_listing(venv_directory)
     venv = assert_app(venv_directory)
     assert canonical_venv_hash == CacheHelper.dir_hash(venv.site_packages_dir)
+
+
+def test_non_hermetic_issue_2004(
+    tmpdir,  # type: Any
+    pex_bdist,  # type: str
+):
+    # type: (...) -> None
+
+    src = os.path.join(str(tmpdir), "src")
+    with safe_open(os.path.join(src, "check_hermetic.py"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                import os
+                import sys
+
+                def check():
+                    if os.environ["PYTHONPATH"] in sys.path:
+                        print("Not hermetic")
+                    else:
+                        print("Hermetic")
+                """
+            )
+        )
+    with safe_open(os.path.join(src, "setup.cfg"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                [metadata]
+                name = hermeticity-checker
+                version = 0.0.1
+
+                [options]
+                py_modules =
+                    check_hermetic
+
+                [options.entry_points]
+                console_scripts =
+                    check-hermetic = check_hermetic:check
+                """
+            )
+        )
+    with safe_open(os.path.join(src, "setup.py"), "w") as fp:
+        fp.write("from setuptools import setup; setup()")
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    check_pex = os.path.join(str(tmpdir), "check.pex")
+    run_pex_command(
+        args=[
+            pex_bdist,
+            src,
+            "-o",
+            check_pex,
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+        ]
+    ).assert_success()
+
+    hermetic_venv = os.path.join(str(tmpdir), "hermetic")
+    non_hermetic_venv = os.path.join(str(tmpdir), "non-hermetic")
+
+    run_pex_tools(check_pex, "venv", hermetic_venv).assert_success()
+    run_pex_tools(check_pex, "venv", "--non-hermetic-scripts", non_hermetic_venv).assert_success()
+
+    hermetic_check = subprocess.check_output(
+        args=[os.path.join(hermetic_venv, "bin", "check-hermetic")],
+        env=make_env(PYTHONPATH=src),
+    )
+    non_hermetic_check = subprocess.check_output(
+        args=[os.path.join(non_hermetic_venv, "bin", "check-hermetic")],
+        env=make_env(PYTHONPATH=src),
+    )
+
+    assert "Hermetic" in str(hermetic_check)
+    assert "Not hermetic" in str(non_hermetic_check)

--- a/tests/resolve/lockfile/test_download_manager.py
+++ b/tests/resolve/lockfile/test_download_manager.py
@@ -128,9 +128,12 @@ def test_storage_version_upgrade(
 
     downloaded_artifact2 = download_manager.store(artifact, project_name)
     assert downloaded_artifact1 == downloaded_artifact2
-    assert 2 == len(set(download_manager.save_calls)), (
-        "Expected two save calls, each with a different atomic directory work dir signalling a "
-        "re-build of the artifact storage"
+    assert 2 == len(
+        download_manager.save_calls
+    ), "Expected two save calls signalling a re-build of the artifact storage."
+    assert 1 == len(set(download_manager.save_calls)), (
+        "Expected each save call is with the same atomic directory work dir signalling a re-build "
+        "of the same artifact storage."
     )
 
 

--- a/tests/resolve/test_target_options.py
+++ b/tests/resolve/test_target_options.py
@@ -22,7 +22,7 @@ from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
 
 if TYPE_CHECKING:
-    from typing import Any, Iterable, List, Optional, Tuple
+    from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
 def compute_target_configuration(
@@ -383,4 +383,149 @@ def test_configure_resolve_local_platforms(
         expected_platforms=[foreign_platform],
         expected_interpreter=py27,
         expected_interpreters=(py310, py27),
+    )
+
+
+def test_configure_resolve_local_platforms_with_complete_platforms(
+    tmpdir,  # type: Any
+    parser,  # type: ArgumentParser
+    py27,  # type: PythonInterpreter
+    py38,  # type: PythonInterpreter
+    py310,  # type: PythonInterpreter
+):
+    # type: (...) -> None
+    target_options.register(parser)
+
+    path_env_var = path_for(py27, py38, py310)
+
+    def dump_complete_platform(
+        name,  # type: str
+        marker_environment,  # type: Dict[str, str]
+        compatible_tags,  # type: List[str]
+        **extra_fields  # type: Any
+    ):
+        # type: (...) -> str
+        path = os.path.join(str(tmpdir), name)
+        with open(path, "w") as fp:
+            json.dump(
+                dict(
+                    marker_environment=marker_environment,
+                    compatible_tags=compatible_tags,
+                    **extra_fields
+                ),
+                fp,
+            )
+        return path
+
+    def assert_local_platforms(
+        complete_platforms,  # type: Iterable[str]
+        expected_platforms,  # type: Iterable[str]
+        expected_interpreter,  # type: Optional[PythonInterpreter]
+        expected_interpreters=None,  # type: Optional[Tuple[PythonInterpreter, ...]]
+    ):
+        # type: (...) -> None
+        args = ["--python-path", path_env_var, "--resolve-local-platforms"]
+        args.extend(
+            itertools.chain.from_iterable(("--complete-platform", p) for p in complete_platforms)
+        )
+        targets = compute_target_configuration(parser, args)
+        # assert tuple(Platform.create(ep) for ep in expected_platforms) == targets.platforms
+        assert_interpreters_configured(targets, expected_interpreter, expected_interpreters)
+
+    py38_complete = dump_complete_platform(
+        "py38",
+        py38.identity.env_markers.as_dict(),
+        py38.identity.supported_tags.to_string_list(),
+    )
+    py38_extra_complete = dump_complete_platform(
+        "py38_extra",
+        py38.identity.env_markers.as_dict(),
+        py38.identity.supported_tags.to_string_list() + ["py3-none-manylinux_2_9999_x86_64"],
+    )
+
+    py38_subset_tags = py38.identity.supported_tags.to_string_list()[:-10]
+    # make the platform different
+    py38_subset_tags[0:2] = py38_subset_tags[0:2:-1]
+    py38_subset_complete = dump_complete_platform(
+        "py38_subset",
+        py38.identity.env_markers.as_dict(),
+        py38_subset_tags,
+    )
+    py310_complete = dump_complete_platform(
+        "py310",
+        py310.identity.env_markers.as_dict(),
+        py310.identity.supported_tags.to_string_list(),
+    )
+    py39999_env_markers = py310.identity.env_markers.as_dict()
+    py39999_env_markers.update(
+        implementation_version="3.9999.0",
+        python_full_version="3.9999.0",
+        python_version="3.9999",
+        sys_platform="linux",
+    )
+    py39999_complete = dump_complete_platform(
+        "other",
+        py39999_env_markers,
+        [
+            "py39999-none-any",
+            "py3-none-any",
+            "py39998-none-any",
+            "py39997-none-any",
+            # you get the idea...
+            "py310-none-any",
+            "py39-none-any",
+            "py38-none-any",
+            "py37-none-any",
+            "py36-none-any",
+            "py35-none-any",
+            "py34-none-any",
+            "py33-none-any",
+            "py32-none-any",
+            "py31-none-any",
+            "py30-none-any",
+        ],
+    )
+
+    # exact match, yay
+    assert_local_platforms(
+        complete_platforms=[py38_complete],
+        expected_platforms=[str(py38.platform)],
+        expected_interpreter=py38,
+    )
+
+    # the interpreter doesn't support some tags, but that's fine
+    assert_local_platforms(
+        complete_platforms=[py38_extra_complete],
+        expected_platforms=[str(py38.platform)],
+        expected_interpreter=py38,
+    )
+
+    # # the interpreter has some tags it supports that this complete platform does not
+    assert_local_platforms(
+        complete_platforms=[py38_subset_complete],
+        expected_platforms=[],
+        expected_interpreter=None,
+    )
+
+    # as above, but now with multiple complete platforms that apply to one interpreter (two
+    # compatible, one not)
+    assert_local_platforms(
+        complete_platforms=[py38_subset_complete, py38_complete, py38_extra_complete],
+        expected_platforms=[],
+        expected_interpreter=None,
+    )
+
+    # wildly different
+    assert_local_platforms(
+        complete_platforms=[py39999_complete],
+        expected_platforms=[],
+        expected_interpreter=None,
+    )
+
+    # multiple
+    assert_local_platforms(
+        complete_platforms=[py38_complete, py310_complete],
+        expected_platforms=[str(py38.platform), str(py310.platform)],
+        expected_interpreter=py38,
+        expected_interpreters=(py38, py310),
     )

--- a/tests/test_atomic_directory.py
+++ b/tests/test_atomic_directory.py
@@ -1,8 +1,24 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pex.atomic_directory import FileLockStyle, _is_bsd_lock
+import errno
+import os
+from contextlib import contextmanager
+
+import pytest
+
+from pex.atomic_directory import AtomicDirectory, FileLockStyle, _is_bsd_lock, atomic_directory
+from pex.common import temporary_dir, touch
 from pex.testing import environment_as
+from pex.typing import TYPE_CHECKING
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock  # type: ignore[no-redef,import]
+
+if TYPE_CHECKING:
+    from typing import Iterator, Optional, Type
 
 
 def test_is_bsd_lock():
@@ -26,3 +42,100 @@ def test_is_bsd_lock():
         ), "Expected the default lock style to be taken from the environment when defined."
         assert not _is_bsd_lock(lock_style=FileLockStyle.POSIX)
         assert _is_bsd_lock(lock_style=FileLockStyle.BSD)
+
+
+@contextmanager
+def maybe_raises(exception=None):
+    # type: (Optional[Type[Exception]]) -> Iterator[None]
+    @contextmanager
+    def noop():
+        yield
+
+    context = noop() if exception is None else pytest.raises(exception)
+    with context:
+        yield
+
+
+def atomic_directory_finalize_test(errno, expect_raises=None):
+    # type: (int, Optional[Type[Exception]]) -> None
+    with mock.patch("os.rename", spec_set=True, autospec=True) as mock_rename:
+        mock_rename.side_effect = OSError(errno, os.strerror(errno))
+        with maybe_raises(expect_raises):
+            AtomicDirectory("to.dir").finalize()
+
+
+def test_atomic_directory_finalize_eexist():
+    # type: () -> None
+    atomic_directory_finalize_test(errno.EEXIST)
+
+
+def test_atomic_directory_finalize_enotempty():
+    # type: () -> None
+    atomic_directory_finalize_test(errno.ENOTEMPTY)
+
+
+def test_atomic_directory_finalize_eperm():
+    # type: () -> None
+    atomic_directory_finalize_test(errno.EPERM, expect_raises=OSError)
+
+
+def test_atomic_directory_empty_workdir_finalize():
+    # type: () -> None
+    with temporary_dir() as sandbox:
+        target_dir = os.path.join(sandbox, "target_dir")
+        assert not os.path.exists(target_dir)
+
+        with atomic_directory(target_dir) as atomic_dir:
+            assert not atomic_dir.is_finalized()
+            assert target_dir == atomic_dir.target_dir
+            assert os.path.exists(atomic_dir.work_dir)
+            assert os.path.isdir(atomic_dir.work_dir)
+            assert [] == os.listdir(atomic_dir.work_dir)
+
+            touch(os.path.join(atomic_dir.work_dir, "created"))
+
+            assert not os.path.exists(target_dir)
+
+        assert not os.path.exists(atomic_dir.work_dir), "The work_dir should always be cleaned up."
+        assert os.path.exists(os.path.join(target_dir, "created"))
+
+
+def test_atomic_directory_empty_workdir_failure():
+    # type: () -> None
+    class SimulatedRuntimeError(RuntimeError):
+        pass
+
+    with temporary_dir() as sandbox:
+        target_dir = os.path.join(sandbox, "target_dir")
+        with pytest.raises(SimulatedRuntimeError):
+            with atomic_directory(target_dir) as atomic_dir:
+                assert not atomic_dir.is_finalized()
+                touch(os.path.join(atomic_dir.work_dir, "created"))
+                raise SimulatedRuntimeError()
+
+        assert not os.path.exists(  # type: ignore[unreachable]
+            atomic_dir.work_dir
+        ), "The work_dir should always be cleaned up."
+        assert not os.path.exists(target_dir), (
+            "When the context raises the work_dir it was given should not be moved to the "
+            "target_dir."
+        )
+
+
+def test_atomic_directory_empty_workdir_finalized():
+    # type: () -> None
+    with temporary_dir() as target_dir:
+        with atomic_directory(target_dir) as work_dir:
+            assert (
+                work_dir.is_finalized()
+            ), "When the target_dir exists no work_dir should be created."
+
+
+def test_atomic_directory_locked_mode():
+    # type: () -> None
+
+    assert AtomicDirectory("unlocked").work_dir != AtomicDirectory("unlocked").work_dir
+    assert (
+        AtomicDirectory("locked", locked=True).work_dir
+        == AtomicDirectory("locked", locked=True).work_dir
+    )

--- a/tests/test_atomic_directory.py
+++ b/tests/test_atomic_directory.py
@@ -1,0 +1,28 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pex.atomic_directory import FileLockStyle, _is_bsd_lock
+from pex.testing import environment_as
+
+
+def test_is_bsd_lock():
+    # type: () -> None
+
+    assert not _is_bsd_lock(
+        lock_style=None
+    ), "Expected the default lock style to be POSIX for maximum compatibility."
+    assert not _is_bsd_lock(lock_style=FileLockStyle.POSIX)
+    assert _is_bsd_lock(lock_style=FileLockStyle.BSD)
+
+    # The hard-coded default is already POSIX, so setting the env var default changes nothing.
+    with environment_as(_PEX_FILE_LOCK_STYLE="posix"):
+        assert not _is_bsd_lock(lock_style=None)
+        assert not _is_bsd_lock(lock_style=FileLockStyle.POSIX)
+        assert _is_bsd_lock(lock_style=FileLockStyle.BSD)
+
+    with environment_as(_PEX_FILE_LOCK_STYLE="bsd"):
+        assert _is_bsd_lock(
+            lock_style=None
+        ), "Expected the default lock style to be taken from the environment when defined."
+        assert not _is_bsd_lock(lock_style=FileLockStyle.POSIX)
+        assert _is_bsd_lock(lock_style=FileLockStyle.BSD)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -8,11 +8,10 @@ from contextlib import contextmanager
 
 import pytest
 
+from pex.atomic_directory import AtomicDirectory, atomic_directory
 from pex.common import (
-    AtomicDirectory,
     Chroot,
     PermPreservingZipFile,
-    atomic_directory,
     can_write_dir,
     chmod_plus_x,
     is_exe,
@@ -40,7 +39,8 @@ def maybe_raises(exception=None):
     def noop():
         yield
 
-    with (noop() if exception is None else pytest.raises(exception)):
+    context = noop() if exception is None else pytest.raises(exception)
+    with context:
         yield
 
 
@@ -73,7 +73,7 @@ def test_atomic_directory_empty_workdir_finalize():
         target_dir = os.path.join(sandbox, "target_dir")
         assert not os.path.exists(target_dir)
 
-        with atomic_directory(target_dir, exclusive=False) as atomic_dir:
+        with atomic_directory(target_dir) as atomic_dir:
             assert not atomic_dir.is_finalized()
             assert target_dir == atomic_dir.target_dir
             assert os.path.exists(atomic_dir.work_dir)
@@ -96,7 +96,7 @@ def test_atomic_directory_empty_workdir_failure():
     with temporary_dir() as sandbox:
         target_dir = os.path.join(sandbox, "target_dir")
         with pytest.raises(SimulatedRuntimeError):
-            with atomic_directory(target_dir, exclusive=False) as atomic_dir:
+            with atomic_directory(target_dir) as atomic_dir:
                 assert not atomic_dir.is_finalized()
                 touch(os.path.join(atomic_dir.work_dir, "created"))
                 raise SimulatedRuntimeError()
@@ -113,7 +113,7 @@ def test_atomic_directory_empty_workdir_failure():
 def test_atomic_directory_empty_workdir_finalized():
     # type: () -> None
     with temporary_dir() as target_dir:
-        with atomic_directory(target_dir, exclusive=False) as work_dir:
+        with atomic_directory(target_dir) as work_dir:
             assert (
                 work_dir.is_finalized()
             ), "When the target_dir exists no work_dir should be created."

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -4,11 +4,9 @@
 import contextlib
 import errno
 import os
-from contextlib import contextmanager
 
 import pytest
 
-from pex.atomic_directory import AtomicDirectory, atomic_directory
 from pex.common import (
     Chroot,
     PermPreservingZipFile,
@@ -29,94 +27,7 @@ except ImportError:
     import mock  # type: ignore[no-redef,import]
 
 if TYPE_CHECKING:
-    from typing import Any, Iterator, Optional, Tuple, Type
-
-
-@contextmanager
-def maybe_raises(exception=None):
-    # type: (Optional[Type[Exception]]) -> Iterator[None]
-    @contextmanager
-    def noop():
-        yield
-
-    context = noop() if exception is None else pytest.raises(exception)
-    with context:
-        yield
-
-
-def atomic_directory_finalize_test(errno, expect_raises=None):
-    # type: (int, Optional[Type[Exception]]) -> None
-    with mock.patch("os.rename", spec_set=True, autospec=True) as mock_rename:
-        mock_rename.side_effect = OSError(errno, os.strerror(errno))
-        with maybe_raises(expect_raises):
-            AtomicDirectory("to.dir").finalize()
-
-
-def test_atomic_directory_finalize_eexist():
-    # type: () -> None
-    atomic_directory_finalize_test(errno.EEXIST)
-
-
-def test_atomic_directory_finalize_enotempty():
-    # type: () -> None
-    atomic_directory_finalize_test(errno.ENOTEMPTY)
-
-
-def test_atomic_directory_finalize_eperm():
-    # type: () -> None
-    atomic_directory_finalize_test(errno.EPERM, expect_raises=OSError)
-
-
-def test_atomic_directory_empty_workdir_finalize():
-    # type: () -> None
-    with temporary_dir() as sandbox:
-        target_dir = os.path.join(sandbox, "target_dir")
-        assert not os.path.exists(target_dir)
-
-        with atomic_directory(target_dir) as atomic_dir:
-            assert not atomic_dir.is_finalized()
-            assert target_dir == atomic_dir.target_dir
-            assert os.path.exists(atomic_dir.work_dir)
-            assert os.path.isdir(atomic_dir.work_dir)
-            assert [] == os.listdir(atomic_dir.work_dir)
-
-            touch(os.path.join(atomic_dir.work_dir, "created"))
-
-            assert not os.path.exists(target_dir)
-
-        assert not os.path.exists(atomic_dir.work_dir), "The work_dir should always be cleaned up."
-        assert os.path.exists(os.path.join(target_dir, "created"))
-
-
-def test_atomic_directory_empty_workdir_failure():
-    # type: () -> None
-    class SimulatedRuntimeError(RuntimeError):
-        pass
-
-    with temporary_dir() as sandbox:
-        target_dir = os.path.join(sandbox, "target_dir")
-        with pytest.raises(SimulatedRuntimeError):
-            with atomic_directory(target_dir) as atomic_dir:
-                assert not atomic_dir.is_finalized()
-                touch(os.path.join(atomic_dir.work_dir, "created"))
-                raise SimulatedRuntimeError()
-
-        assert not os.path.exists(  # type: ignore[unreachable]
-            atomic_dir.work_dir
-        ), "The work_dir should always be cleaned up."
-        assert not os.path.exists(target_dir), (
-            "When the context raises the work_dir it was given should not be moved to the "
-            "target_dir."
-        )
-
-
-def test_atomic_directory_empty_workdir_finalized():
-    # type: () -> None
-    with temporary_dir() as target_dir:
-        with atomic_directory(target_dir) as work_dir:
-            assert (
-                work_dir.is_finalized()
-            ), "When the target_dir exists no work_dir should be created."
+    from typing import Any, Iterator, Tuple
 
 
 def extract_perms(path):

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -4,7 +4,8 @@ import re
 
 import pytest
 
-from pex.common import AtomicDirectory, PermPreservingZipFile
+from pex.atomic_directory import AtomicDirectory
+from pex.common import PermPreservingZipFile
 from pex.compatibility import PY2
 from pex.enum import Enum, qualified_name
 
@@ -104,10 +105,10 @@ def test_qualified_name():
         qualified_name
     ), "Expected functions to be handled"
 
-    assert "pex.common.AtomicDirectory" == qualified_name(
+    assert "pex.atomic_directory.AtomicDirectory" == qualified_name(
         AtomicDirectory
     ), "Expected custom types to be handled."
-    expected_prefix = "pex.common." if PY2 else "pex.common.AtomicDirectory."
+    expected_prefix = "pex.atomic_directory." if PY2 else "pex.atomic_directory.AtomicDirectory."
     assert expected_prefix + "finalize" == qualified_name(
         AtomicDirectory.finalize
     ), "Expected methods to be handled."

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -13,9 +13,7 @@ from textwrap import dedent
 
 import pytest
 
-from pex import interpreter
 from pex.common import chmod_plus_x, safe_mkdir, safe_mkdtemp, temporary_dir, touch
-from pex.compatibility import PY3
 from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
 from pex.jobs import Job
@@ -55,13 +53,7 @@ class TestPythonInterpreter(object):
     def test_all_does_not_raise_with_empty_path_envvar(self):
         # type: () -> None
         """additionally, tests that the module does not raise at import."""
-        with patch.dict(os.environ, clear=True):
-            if PY3:
-                import importlib
-
-                importlib.reload(interpreter)
-            else:
-                reload(interpreter)
+        with patch.dict(os.environ, clear=True), PythonInterpreter._cleared_memory_cache():
             PythonInterpreter.all()
 
     TEST_INTERPRETER1_VERSION = PY39
@@ -416,7 +408,9 @@ def test_identify_cwd_isolation_issues_1231(tmpdir):
     subprocess.check_call(args=[pip, "install", "--target", polluted_cwd, "pex==2.1.16"])
 
     pex_root = os.path.join(str(tmpdir), "pex_root")
-    with pushd(polluted_cwd), ENV.patch(PEX_ROOT=pex_root):
+    with pushd(polluted_cwd), ENV.patch(
+        PEX_ROOT=pex_root
+    ), PythonInterpreter._cleared_memory_cache():
         interp = PythonInterpreter.from_binary(python38)
 
     interp_info_files = {

--- a/tests/test_interpreter_constraints.py
+++ b/tests/test_interpreter_constraints.py
@@ -5,11 +5,23 @@ import itertools
 import sys
 
 from pex import interpreter_constraints
-from pex.interpreter_constraints import COMPATIBLE_PYTHON_VERSIONS, Lifecycle
+from pex.interpreter import PythonInterpreter
+from pex.interpreter_constraints import COMPATIBLE_PYTHON_VERSIONS, InterpreterConstraint, Lifecycle
+from pex.testing import PY27, PY38, PY310, ensure_python_interpreter
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import List, Tuple
+
+
+def test_parse():
+    py38 = PythonInterpreter.from_binary(ensure_python_interpreter(PY38))
+
+    assert py38 in InterpreterConstraint.parse("==3.8.*")
+    assert py38 in InterpreterConstraint.parse("CPython==3.8.*")
+    assert py38 in InterpreterConstraint.parse("==3.8.*", default_interpreter="CPython")
+    assert py38 not in InterpreterConstraint.parse("==3.8.*", default_interpreter="PyPy")
+    assert py38 not in InterpreterConstraint.parse("PyPy==3.8.*")
 
 
 def iter_compatible_versions(*requires_python):

--- a/tests/test_pth.py
+++ b/tests/test_pth.py
@@ -1,0 +1,53 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+
+from pex.common import temporary_dir
+from pex.compatibility import to_bytes
+from pex.pth import iter_pth_paths
+from pex.typing import TYPE_CHECKING
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock  # type: ignore[no-redef,import]
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, List
+
+
+@mock.patch("os.path.exists", autospec=True, spec_set=True)
+def test_iter_pth_paths(mock_exists):
+    # type: (Any) -> None
+    # Ensure path checking always returns True for dummy paths.
+    mock_exists.return_value = True
+
+    with temporary_dir() as tmpdir:
+        in_tmp = lambda f: os.path.join(tmpdir, f)
+
+        PTH_TEST_MAPPING = {
+            # A mapping of .pth file content -> expected paths.
+            "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python\n": [
+                "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python"
+            ],
+            "relative_path\nrelative_path2\n\nrelative_path3": [
+                in_tmp("relative_path"),
+                in_tmp("relative_path2"),
+                in_tmp("relative_path3"),
+            ],
+            "duplicate_path\nduplicate_path": [in_tmp("duplicate_path")],
+            "randompath\nimport nosuchmodule\n": [in_tmp("randompath")],
+            "import sys\nfoo\n/bar/baz": [in_tmp("foo"), "/bar/baz"],
+            "import nosuchmodule\nfoo": [],
+            "import nosuchmodule\n": [],
+            "import bad)syntax\n": [],
+        }  # type: Dict[str, List[str]]
+
+        for i, pth_content in enumerate(PTH_TEST_MAPPING):
+            pth_tmp_path = os.path.abspath(os.path.join(tmpdir, "test%s.pth" % i))
+            with open(pth_tmp_path, "wb") as f:
+                f.write(to_bytes(pth_content))
+            assert sorted(PTH_TEST_MAPPING[pth_content]) == sorted(
+                list(iter_pth_paths(pth_tmp_path))
+            )

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,8 @@ passenv =
     SSH_AUTH_SOCK
 setenv =
     pip20: _PEX_PIP_VERSION=20.3.4-patched
-    pip22: _PEX_PIP_VERSION=22.2.2
+    pip22_2: _PEX_PIP_VERSION=22.2.2
+    pip22_3: _PEX_PIP_VERSION=22.3
     # Python 3 (until a fix here in 3.9: https://bugs.python.org/issue13601) switched from stderr
     # being unbuffered to stderr being buffered by default. This can lead to tests checking stderr
     # failing to see what they expect if the stderr buffer block has not been flushed. Force stderr
@@ -61,7 +62,7 @@ whitelist_externals =
     bash
     git
 
-[testenv:py{py27-subprocess,py27,py35,py36,py37,py38,py39,27,35,36,37,38,39,310,311}-{,pip20-,pip22-}integration]
+[testenv:py{py27-subprocess,py27,py35,py36,py37,py38,py39,27,35,36,37,38,39,310,311}-{,pip20-,pip22_2-,pip22_3-}integration]
 deps =
     pytest-xdist==1.34.0
     {[testenv]deps}


### PR DESCRIPTION
I did a series of merge commits to bring the Windows/wip branch closer to main. To select the versions I merged in, I jumped ahead, tried to merge, and then stepped back a version until I found a version that either had no merge conflicts or was the next version.

The last time you merged main in was `v2.1.109`. These are my merge commits:
- `v2.1.110` 967d126fb97905b3c847c3b6759c820e222f39c9
- `v2.1.111` 3ef4bcf3a62709378e1d48f3b22e3799acbd09ab
- `v2.1.112` a2ea4d2dd34a1c691f845a02325eed04b20a84b9
- `v2.1.113` 5d3c3eecfcc4aa63c300ad1940921525916a9c64
- `v2.1.119` 5e75991cf811c571a072104e30d8ea98fcca3fef
- `v2.1.120` a7223e360df341e48a89ca35f26c0876370afa1f

I stopped at `v2.1.120` because it wasn't immediately clear what fix to use here since pyenv-win probably its own versions that don't align with pyenv's:
https://github.com/jsirois/pex/blob/a7223e360df341e48a89ca35f26c0876370afa1f/pex/testing.py#L604-L608
_edit: eww. I just saw a typo in my TODO. :facepalm:_

@jsirois Is doing this helpful? Or is there a better way to help with adding Windows support?

Before I keep going, I want to see what you think of collaborating on this.